### PR TITLE
Add externalized JMeter support & JTL generation

### DIFF
--- a/scenario01/jmeter/01-Solution1-PublicPartnerPrivateAPI.jmx
+++ b/scenario01/jmeter/01-Solution1-PublicPartnerPrivateAPI.jmx
@@ -4154,8 +4154,8 @@ vars.put(&quot;encoded_ClientCredentials&quot;, new String(encoded_ClientCredent
           <name>saveConfig</name>
           <value class="SampleSaveConfiguration">
             <time>true</time>
-            <latency>true</latency>
-            <timestamp>true</timestamp>
+            <latency>false</latency>
+            <timestamp>false</timestamp>
             <success>true</success>
             <label>true</label>
             <code>true</code>
@@ -4164,24 +4164,25 @@ vars.put(&quot;encoded_ClientCredentials&quot;, new String(encoded_ClientCredent
             <dataType>true</dataType>
             <encoding>false</encoding>
             <assertions>true</assertions>
-            <subresults>true</subresults>
-            <responseData>false</responseData>
-            <samplerData>false</samplerData>
-            <xml>false</xml>
+            <subresults>false</subresults>
+            <responseData>true</responseData>
+            <samplerData>true</samplerData>
+            <xml>true</xml>
             <fieldNames>true</fieldNames>
-            <responseHeaders>false</responseHeaders>
-            <requestHeaders>false</requestHeaders>
+            <responseHeaders>true</responseHeaders>
+            <requestHeaders>true</requestHeaders>
             <responseDataOnError>false</responseDataOnError>
             <saveAssertionResultsFailureMessage>true</saveAssertionResultsFailureMessage>
             <assertionsResultsToSave>0</assertionsResultsToSave>
-            <bytes>true</bytes>
             <sentBytes>true</sentBytes>
+            <url>true</url>
+            <hostname>true</hostname>
             <threadCounts>true</threadCounts>
-            <idleTime>true</idleTime>
+            <sampleCount>true</sampleCount>
             <connectTime>true</connectTime>
           </value>
         </objProp>
-        <stringProp name="filename"></stringProp>
+        <stringProp name="filename">scenario-01-results.jtl</stringProp>
       </ResultCollector>
       <hashTree/>
     </hashTree>

--- a/scenario01/jmeter/02-Solution1-OwnershipAndColDevelopment.jmx
+++ b/scenario01/jmeter/02-Solution1-OwnershipAndColDevelopment.jmx
@@ -2174,8 +2174,8 @@ vars.put(&quot;encoded_ClientCredentials&quot;, new String(encoded_ClientCredent
           <name>saveConfig</name>
           <value class="SampleSaveConfiguration">
             <time>true</time>
-            <latency>true</latency>
-            <timestamp>true</timestamp>
+            <latency>false</latency>
+            <timestamp>false</timestamp>
             <success>true</success>
             <label>true</label>
             <code>true</code>
@@ -2184,24 +2184,25 @@ vars.put(&quot;encoded_ClientCredentials&quot;, new String(encoded_ClientCredent
             <dataType>true</dataType>
             <encoding>false</encoding>
             <assertions>true</assertions>
-            <subresults>true</subresults>
-            <responseData>false</responseData>
-            <samplerData>false</samplerData>
-            <xml>false</xml>
+            <subresults>false</subresults>
+            <responseData>true</responseData>
+            <samplerData>true</samplerData>
+            <xml>true</xml>
             <fieldNames>true</fieldNames>
-            <responseHeaders>false</responseHeaders>
-            <requestHeaders>false</requestHeaders>
+            <responseHeaders>true</responseHeaders>
+            <requestHeaders>true</requestHeaders>
             <responseDataOnError>false</responseDataOnError>
             <saveAssertionResultsFailureMessage>true</saveAssertionResultsFailureMessage>
             <assertionsResultsToSave>0</assertionsResultsToSave>
             <bytes>true</bytes>
             <sentBytes>true</sentBytes>
+            <fileName>true</fileName>
             <threadCounts>true</threadCounts>
-            <idleTime>true</idleTime>
+            <sampleCount>true</sampleCount>
             <connectTime>true</connectTime>
           </value>
         </objProp>
-        <stringProp name="filename"></stringProp>
+        <stringProp name="filename">scenario-01-results.jtl</stringProp>
       </ResultCollector>
       <hashTree/>
     </hashTree>

--- a/scenario01/jmeter/03-Solution1-DeveloperOptimizedAPIDevelopment.jmx
+++ b/scenario01/jmeter/03-Solution1-DeveloperOptimizedAPIDevelopment.jmx
@@ -3015,8 +3015,8 @@ vars.put(&quot;encoded_ClientCredentials&quot;, new String(encoded_ClientCredent
           <name>saveConfig</name>
           <value class="SampleSaveConfiguration">
             <time>true</time>
-            <latency>true</latency>
-            <timestamp>true</timestamp>
+            <latency>false</latency>
+            <timestamp>false</timestamp>
             <success>true</success>
             <label>true</label>
             <code>true</code>
@@ -3025,24 +3025,23 @@ vars.put(&quot;encoded_ClientCredentials&quot;, new String(encoded_ClientCredent
             <dataType>true</dataType>
             <encoding>false</encoding>
             <assertions>true</assertions>
-            <subresults>true</subresults>
-            <responseData>false</responseData>
+            <subresults>false</subresults>
+            <responseData>true</responseData>
             <samplerData>false</samplerData>
-            <xml>false</xml>
+            <xml>true</xml>
             <fieldNames>true</fieldNames>
-            <responseHeaders>false</responseHeaders>
-            <requestHeaders>false</requestHeaders>
+            <responseHeaders>true</responseHeaders>
+            <requestHeaders>true</requestHeaders>
             <responseDataOnError>false</responseDataOnError>
             <saveAssertionResultsFailureMessage>true</saveAssertionResultsFailureMessage>
             <assertionsResultsToSave>0</assertionsResultsToSave>
-            <bytes>true</bytes>
             <sentBytes>true</sentBytes>
             <threadCounts>true</threadCounts>
-            <idleTime>true</idleTime>
+            <sampleCount>true</sampleCount>
             <connectTime>true</connectTime>
           </value>
         </objProp>
-        <stringProp name="filename"></stringProp>
+        <stringProp name="filename">scenario-01-results.jtl</stringProp>
       </ResultCollector>
       <hashTree/>
     </hashTree>

--- a/scenario01/run-scenario.sh
+++ b/scenario01/run-scenario.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright (c) 2018, WSO2 Inc. (http://wso2.com) All Rights Reserved.
+# Copyright (c) 2017, WSO2 Inc. (http://wso2.com) All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,10 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-#run pre-scenario-steps
-source $rootDir/jmeter/04-pre-scenario-steps.sh
-#TODO: Verify output of above step.
-#run jmeter file/s.
-$JMETER_HOME/bin/jmeter.sh -n -t 01-Scenario04-ManageLifeCycle.jmx -p resources/user.properties
-#run post-scenario-steps
-source jmeter/04-post-scenario-steps.sh
+$JMETER_HOME/bin/jmeter.sh -n -t jmeter/01-Solution1-PublicPartnerPrivateAPI.jmx -p resources/user.properties
+$JMETER_HOME/bin/jmeter.sh -n -t jmeter/02-Solution1-OwnershipAndColDevelopment.jmx -p resources/user.properties
+$JMETER_HOME/bin/jmeter.sh -n -t jmeter/03-Solution1-DeveloperOptimizedAPIDevelopment.jmx -p resources/user.properties

--- a/scenario03/jmeter/01-Scenario03-App-Development-with-APIs.jmx
+++ b/scenario03/jmeter/01-Scenario03-App-Development-with-APIs.jmx
@@ -1184,8 +1184,8 @@ ${__setProperty(access_token_publish, ${access_token_publish})};</stringProp>
           <name>saveConfig</name>
           <value class="SampleSaveConfiguration">
             <time>true</time>
-            <latency>true</latency>
-            <timestamp>true</timestamp>
+            <latency>false</latency>
+            <timestamp>false</timestamp>
             <success>true</success>
             <label>true</label>
             <code>true</code>
@@ -1195,12 +1195,12 @@ ${__setProperty(access_token_publish, ${access_token_publish})};</stringProp>
             <encoding>false</encoding>
             <assertions>true</assertions>
             <subresults>false</subresults>
-            <responseData>false</responseData>
+            <responseData>true</responseData>
             <samplerData>true</samplerData>
             <xml>true</xml>
             <fieldNames>true</fieldNames>
             <responseHeaders>true</responseHeaders>
-            <requestHeaders>false</requestHeaders>
+            <requestHeaders>true</requestHeaders>
             <responseDataOnError>false</responseDataOnError>
             <saveAssertionResultsFailureMessage>true</saveAssertionResultsFailureMessage>
             <assertionsResultsToSave>0</assertionsResultsToSave>
@@ -1210,12 +1210,11 @@ ${__setProperty(access_token_publish, ${access_token_publish})};</stringProp>
             <fileName>true</fileName>
             <hostname>true</hostname>
             <threadCounts>true</threadCounts>
-            <idleTime>true</idleTime>
-            <connectTime>true</connectTime>
+            <sampleCount>true</sampleCount>
           </value>
         </objProp>
         <stringProp name="TestPlan.comments">148f9080-678c-4714-b56b-936db0c7a648</stringProp>
-        <stringProp name="filename">scenarioResults.jtl</stringProp>
+        <stringProp name="filename">scenario-03-results.jtl</stringProp>
       </ResultCollector>
       <hashTree/>
       <ResultCollector guiclass="SimpleDataWriter" testclass="ResultCollector" testname="Simple Data Writer" enabled="true">

--- a/scenario03/run-scenario.sh
+++ b/scenario03/run-scenario.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright (c) 2018, WSO2 Inc. (http://wso2.com) All Rights Reserved.
+# Copyright (c) 2017, WSO2 Inc. (http://wso2.com) All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,10 +14,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-#run pre-scenario-steps
-source $rootDir/jmeter/04-pre-scenario-steps.sh
-#TODO: Verify output of above step.
-#run jmeter file/s.
-$JMETER_HOME/bin/jmeter.sh -n -t 01-Scenario04-ManageLifeCycle.jmx -p resources/user.properties
-#run post-scenario-steps
-source jmeter/04-post-scenario-steps.sh
+$JMETER_HOME/bin/jmeter.sh -n -t jmeter/01-Scenario03-App-Development-with-APIs.jmx -p resources/user.properties

--- a/scenario04/jmeter/01-Scenario04-ManageLifeCycle.jmx
+++ b/scenario04/jmeter/01-Scenario04-ManageLifeCycle.jmx
@@ -1933,8 +1933,8 @@ byte[] b64encrypted = Base64.encodeBase64(concatValue.getBytes());
           <name>saveConfig</name>
           <value class="SampleSaveConfiguration">
             <time>true</time>
-            <latency>true</latency>
-            <timestamp>true</timestamp>
+            <latency>false</latency>
+            <timestamp>false</timestamp>
             <success>true</success>
             <label>true</label>
             <code>true</code>
@@ -1953,18 +1953,15 @@ byte[] b64encrypted = Base64.encodeBase64(concatValue.getBytes());
             <responseDataOnError>false</responseDataOnError>
             <saveAssertionResultsFailureMessage>true</saveAssertionResultsFailureMessage>
             <assertionsResultsToSave>0</assertionsResultsToSave>
-            <bytes>true</bytes>
             <sentBytes>true</sentBytes>
             <url>true</url>
             <fileName>true</fileName>
             <hostname>true</hostname>
             <threadCounts>true</threadCounts>
             <sampleCount>true</sampleCount>
-            <idleTime>true</idleTime>
-            <connectTime>true</connectTime>
           </value>
         </objProp>
-        <stringProp name="filename">scenario-results.jtl</stringProp>
+        <stringProp name="filename">scenario-04-results.jtl</stringProp>
       </ResultCollector>
       <hashTree/>
       <ResultCollector guiclass="SimpleDataWriter" testclass="ResultCollector" testname="Simple Data Writer" enabled="true">

--- a/scenario04/run-scenario.sh
+++ b/scenario04/run-scenario.sh
@@ -18,6 +18,6 @@
 source $rootDir/jmeter/04-pre-scenario-steps.sh
 #TODO: Verify output of above step.
 #run jmeter file/s.
-$JMETER_HOME/bin/jmeter.sh -n -t 01-Scenario04-ManageLifeCycle.jmx -p resources/user.properties
+$JMETER_HOME/bin/jmeter.sh -n -t jmeter/01-Scenario04-ManageLifeCycle.jmx -p resources/user.properties
 #run post-scenario-steps
 source jmeter/04-post-scenario-steps.sh

--- a/scenario05/jmeter/01-Solution-05-APIVersioning.jmx
+++ b/scenario05/jmeter/01-Solution-05-APIVersioning.jmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<jmeterTestPlan version="1.2" properties="3.2" jmeter="3.2 r1790748">
+<jmeterTestPlan version="1.2" properties="3.2" jmeter="3.3 r1808647">
   <hashTree>
     <TestPlan guiclass="TestPlanGui" testclass="TestPlan" testname="API Versioning" enabled="true">
       <stringProp name="TestPlan.comments"></stringProp>
@@ -14,8 +14,6 @@
       <CookieManager guiclass="CookiePanel" testclass="CookieManager" testname="HTTP Cookie Manager" enabled="true">
         <collectionProp name="CookieManager.cookies"/>
         <boolProp name="CookieManager.clearEachIteration">false</boolProp>
-        <stringProp name="CookieManager.policy">standard</stringProp>
-        <stringProp name="CookieManager.implementation">org.apache.jmeter.protocol.http.control.HC4CookieHandler</stringProp>
       </CookieManager>
       <hashTree/>
       <Arguments guiclass="ArgumentsPanel" testclass="Arguments" testname="User Defined Variables" enabled="true">
@@ -1702,8 +1700,8 @@ log.info(&quot;ApplicationId:&quot; + props.get(&quot;application_id_no&quot;));
             <name>saveConfig</name>
             <value class="SampleSaveConfiguration">
               <time>true</time>
-              <latency>true</latency>
-              <timestamp>true</timestamp>
+              <latency>false</latency>
+              <timestamp>false</timestamp>
               <success>true</success>
               <label>true</label>
               <code>true</code>
@@ -1712,24 +1710,23 @@ log.info(&quot;ApplicationId:&quot; + props.get(&quot;application_id_no&quot;));
               <dataType>true</dataType>
               <encoding>false</encoding>
               <assertions>true</assertions>
-              <subresults>true</subresults>
-              <responseData>false</responseData>
-              <samplerData>false</samplerData>
-              <xml>false</xml>
+              <subresults>false</subresults>
+              <responseData>true</responseData>
+              <samplerData>true</samplerData>
+              <xml>true</xml>
               <fieldNames>true</fieldNames>
-              <responseHeaders>false</responseHeaders>
-              <requestHeaders>false</requestHeaders>
+              <responseHeaders>true</responseHeaders>
+              <requestHeaders>true</requestHeaders>
               <responseDataOnError>false</responseDataOnError>
               <saveAssertionResultsFailureMessage>true</saveAssertionResultsFailureMessage>
               <assertionsResultsToSave>0</assertionsResultsToSave>
-              <bytes>true</bytes>
               <sentBytes>true</sentBytes>
               <threadCounts>true</threadCounts>
-              <idleTime>true</idleTime>
+              <sampleCount>true</sampleCount>
               <connectTime>true</connectTime>
             </value>
           </objProp>
-          <stringProp name="filename"></stringProp>
+          <stringProp name="filename">scenario-05-results.jtl</stringProp>
         </ResultCollector>
         <hashTree/>
       </hashTree>

--- a/scenario05/run-scenario.sh
+++ b/scenario05/run-scenario.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright (c) 2018, WSO2 Inc. (http://wso2.com) All Rights Reserved.
+# Copyright (c) 2017, WSO2 Inc. (http://wso2.com) All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,10 +14,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-#run pre-scenario-steps
-source $rootDir/jmeter/04-pre-scenario-steps.sh
-#TODO: Verify output of above step.
-#run jmeter file/s.
-$JMETER_HOME/bin/jmeter.sh -n -t 01-Scenario04-ManageLifeCycle.jmx -p resources/user.properties
-#run post-scenario-steps
-source jmeter/04-post-scenario-steps.sh
+$JMETER_HOME/bin/jmeter.sh -n -t jmeter/01-Solution-05-APIVersioning.jmx -p resources/user.properties

--- a/scenario06/jmeter/01-Solution-06-ApplicationLevelThrottling.jmx
+++ b/scenario06/jmeter/01-Solution-06-ApplicationLevelThrottling.jmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<jmeterTestPlan version="1.2" properties="3.2" jmeter="3.2 r1790748">
+<jmeterTestPlan version="1.2" properties="3.2" jmeter="3.3 r1808647">
   <hashTree>
     <TestPlan guiclass="TestPlanGui" testclass="TestPlan" testname="API Governance - Application Level Throttling" enabled="true">
       <stringProp name="TestPlan.comments">Using Per quota-token </stringProp>
@@ -81,7 +81,6 @@
           <CookieManager guiclass="CookiePanel" testclass="CookieManager" testname="HTTP Cookie Manager" enabled="true">
             <collectionProp name="CookieManager.cookies"/>
             <boolProp name="CookieManager.clearEachIteration">false</boolProp>
-            <stringProp name="CookieManager.implementation">org.apache.jmeter.protocol.http.control.HC4CookieHandler</stringProp>
           </CookieManager>
           <hashTree/>
           <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="registerClient" enabled="true">
@@ -283,7 +282,6 @@ vars.put(&quot;throttlingTier&quot;, tier);</stringProp>
             <CookieManager guiclass="CookiePanel" testclass="CookieManager" testname="HTTP Cookie Manager" enabled="true">
               <collectionProp name="CookieManager.cookies"/>
               <boolProp name="CookieManager.clearEachIteration">false</boolProp>
-              <stringProp name="CookieManager.implementation">org.apache.jmeter.protocol.http.control.HC4CookieHandler</stringProp>
             </CookieManager>
             <hashTree/>
             <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="createApp" enabled="true">
@@ -353,7 +351,6 @@ vars.put(&quot;throttlingTier&quot;, tier);</stringProp>
             <CookieManager guiclass="CookiePanel" testclass="CookieManager" testname="HTTP Cookie Manager" enabled="true">
               <collectionProp name="CookieManager.cookies"/>
               <boolProp name="CookieManager.clearEachIteration">false</boolProp>
-              <stringProp name="CookieManager.implementation">org.apache.jmeter.protocol.http.control.HC4CookieHandler</stringProp>
             </CookieManager>
             <hashTree/>
             <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="Search API" enabled="true">
@@ -926,7 +923,6 @@ ${__setProperty(forthAccessToken, ${accessToken4})};</stringProp>
           <CookieManager guiclass="CookiePanel" testclass="CookieManager" testname="HTTP Cookie Manager" enabled="true">
             <collectionProp name="CookieManager.cookies"/>
             <boolProp name="CookieManager.clearEachIteration">false</boolProp>
-            <stringProp name="CookieManager.implementation">org.apache.jmeter.protocol.http.control.HC4CookieHandler</stringProp>
           </CookieManager>
           <hashTree/>
           <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="listApplication&amp;getAppID" enabled="true">
@@ -1024,8 +1020,8 @@ ${__setProperty(forthAccessToken, ${accessToken4})};</stringProp>
           <name>saveConfig</name>
           <value class="SampleSaveConfiguration">
             <time>true</time>
-            <latency>true</latency>
-            <timestamp>true</timestamp>
+            <latency>false</latency>
+            <timestamp>false</timestamp>
             <success>true</success>
             <label>true</label>
             <code>true</code>
@@ -1034,24 +1030,23 @@ ${__setProperty(forthAccessToken, ${accessToken4})};</stringProp>
             <dataType>true</dataType>
             <encoding>false</encoding>
             <assertions>true</assertions>
-            <subresults>true</subresults>
-            <responseData>false</responseData>
-            <samplerData>false</samplerData>
-            <xml>false</xml>
+            <subresults>false</subresults>
+            <responseData>true</responseData>
+            <samplerData>true</samplerData>
+            <xml>true</xml>
             <fieldNames>true</fieldNames>
-            <responseHeaders>false</responseHeaders>
-            <requestHeaders>false</requestHeaders>
+            <responseHeaders>true</responseHeaders>
+            <requestHeaders>true</requestHeaders>
             <responseDataOnError>false</responseDataOnError>
             <saveAssertionResultsFailureMessage>true</saveAssertionResultsFailureMessage>
             <assertionsResultsToSave>0</assertionsResultsToSave>
-            <bytes>true</bytes>
             <sentBytes>true</sentBytes>
             <threadCounts>true</threadCounts>
-            <idleTime>true</idleTime>
+            <sampleCount>true</sampleCount>
             <connectTime>true</connectTime>
           </value>
         </objProp>
-        <stringProp name="filename"></stringProp>
+        <stringProp name="filename">scenario-06-results.jtl</stringProp>
       </ResultCollector>
       <hashTree/>
       <ResultCollector guiclass="SummaryReport" testclass="ResultCollector" testname="Summary Report" enabled="true">

--- a/scenario06/run-scenario.sh
+++ b/scenario06/run-scenario.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright (c) 2018, WSO2 Inc. (http://wso2.com) All Rights Reserved.
+# Copyright (c) 2017, WSO2 Inc. (http://wso2.com) All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,10 +14,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-#run pre-scenario-steps
-source $rootDir/jmeter/04-pre-scenario-steps.sh
-#TODO: Verify output of above step.
-#run jmeter file/s.
-$JMETER_HOME/bin/jmeter.sh -n -t 01-Scenario04-ManageLifeCycle.jmx -p resources/user.properties
-#run post-scenario-steps
-source jmeter/04-post-scenario-steps.sh
+$JMETER_HOME/bin/jmeter.sh -n -t jmeter/01-Solution-06-ApplicationLevelThrottling.jmx -p resources/user.properties

--- a/scenario09/jmeter/01-Solution-09-DeveloperEnablementnCommunityBuidingSSOForAPIStoreWithSocialMedia.jmx
+++ b/scenario09/jmeter/01-Solution-09-DeveloperEnablementnCommunityBuidingSSOForAPIStoreWithSocialMedia.jmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<jmeterTestPlan version="1.2" properties="3.2" jmeter="3.2 r1790748">
+<jmeterTestPlan version="1.2" properties="3.2" jmeter="3.3 r1808647">
   <hashTree>
     <TestPlan guiclass="TestPlanGui" testclass="TestPlan" testname="Developer Enablement and Community Building" enabled="true">
       <stringProp name="TestPlan.comments"></stringProp>
@@ -14,7 +14,6 @@
       <CookieManager guiclass="CookiePanel" testclass="CookieManager" testname="HTTP Cookie Manager" enabled="true">
         <collectionProp name="CookieManager.cookies"/>
         <boolProp name="CookieManager.clearEachIteration">false</boolProp>
-        <stringProp name="CookieManager.implementation">org.apache.jmeter.protocol.http.control.HC4CookieHandler</stringProp>
       </CookieManager>
       <hashTree/>
       <Arguments guiclass="ArgumentsPanel" testclass="Arguments" testname="Variables" enabled="true">
@@ -1524,8 +1523,8 @@ try {
           <name>saveConfig</name>
           <value class="SampleSaveConfiguration">
             <time>true</time>
-            <latency>true</latency>
-            <timestamp>true</timestamp>
+            <latency>false</latency>
+            <timestamp>false</timestamp>
             <success>true</success>
             <label>true</label>
             <code>true</code>
@@ -1534,24 +1533,23 @@ try {
             <dataType>true</dataType>
             <encoding>false</encoding>
             <assertions>true</assertions>
-            <subresults>true</subresults>
-            <responseData>false</responseData>
-            <samplerData>false</samplerData>
-            <xml>false</xml>
+            <subresults>false</subresults>
+            <responseData>true</responseData>
+            <samplerData>true</samplerData>
+            <xml>true</xml>
             <fieldNames>true</fieldNames>
-            <responseHeaders>false</responseHeaders>
-            <requestHeaders>false</requestHeaders>
+            <responseHeaders>true</responseHeaders>
+            <requestHeaders>true</requestHeaders>
             <responseDataOnError>false</responseDataOnError>
             <saveAssertionResultsFailureMessage>true</saveAssertionResultsFailureMessage>
             <assertionsResultsToSave>0</assertionsResultsToSave>
-            <bytes>true</bytes>
             <sentBytes>true</sentBytes>
             <threadCounts>true</threadCounts>
-            <idleTime>true</idleTime>
+            <sampleCount>true</sampleCount>
             <connectTime>true</connectTime>
           </value>
         </objProp>
-        <stringProp name="filename"></stringProp>
+        <stringProp name="filename">scenario-09-results.jtl</stringProp>
       </ResultCollector>
       <hashTree/>
     </hashTree>

--- a/scenario09/run-scenario.sh
+++ b/scenario09/run-scenario.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright (c) 2018, WSO2 Inc. (http://wso2.com) All Rights Reserved.
+# Copyright (c) 2017, WSO2 Inc. (http://wso2.com) All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,10 +14,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-#run pre-scenario-steps
-source $rootDir/jmeter/04-pre-scenario-steps.sh
-#TODO: Verify output of above step.
-#run jmeter file/s.
-$JMETER_HOME/bin/jmeter.sh -n -t 01-Scenario04-ManageLifeCycle.jmx -p resources/user.properties
-#run post-scenario-steps
-source jmeter/04-post-scenario-steps.sh
+$JMETER_HOME/bin/jmeter.sh -n -t jmeter/01-Solution-09-DeveloperEnablementnCommunityBuidingSSOForAPIStoreWithSocialMedia.jmx -p resources/user.properties


### PR DESCRIPTION
## Purpose

Scenario tests should support externalized JMeter engine. This change will add jmx script execution via run-scenario.sh script which will invoke externalized JMeter.

Suggested Assignees
@chaminda , @dilinisg 