### PR TITLE
Adding self sign up test cases for 4.0.0 UI test suit

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,149 @@
+# WSO2 API Manager Portals
+        
+
+---
+
+
+[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
+[![stackoverflow](https://img.shields.io/badge/stackoverflow-wso2am-orange)](https://stackoverflow.com/tags/wso2-am/)
+[![slack](https://img.shields.io/badge/slack-wso2--apim-blueviolet)](https://join.slack.com/t/wso2-apim/shared_invite/enQtNzEzMzk5Njc5MzM0LTgwODI3NmQ1MjI0ZDQyMGNmZGI4ZjdkZmI1ZWZmMjNkY2E0NmY3ZmExYjkxYThjNzNkOTU2NWJmYzM4YzZiOWU?src=sidebar)
+
+---
+
+|  Branch / Status | Azure | Jenkins |
+| :------------ |:------------- |:-------------
+| master      | [![Build Status](https://dev.azure.com/apim-apps/apim-apps/_apis/build/status/wso2.apim-apps?branchName=main)](https://dev.azure.com/apim-apps/apim-apps/_build/latest?definitionId=2&branchName=main) | [![Build Status](https://wso2.org/jenkins/view/platform/job/platform-builds/job/apim-apps/badge/icon)](https://wso2.org/jenkins/view/platform/job/platform-builds/job/apim-apps/) |
+
+
+WSO2 API Manager apps consists of several loosely coupled modules.
+
+        * API Publisher portal
+        * API Developer portal
+        * API Admin portal
+        * Portals integration tests
+Setup build environment
+==================================
+
+1. Install NodeJS 16.x or later LTS version from [https://nodejs.org/en/download/](https://nodejs.org/en/download/).
+ > **_Note :-_** 
+   >  
+   > You may use [nvm](https://github.com/nvm-sh/nvm) tool to manage NodeJS on your development environment
+   >
+
+> **_Note :-_** 
+   >  
+   > You can skip following steps if you do not want to build [product-apim](https://github.com/wso2/product-apim) binaries
+   >
+
+2. Install Maven from [https://maven.apache.org/download.cgi](https://maven.apache.org/download.cgi). * For Maven 3.8 and up, please check the Troubleshoot section.
+3. Install JDK 1.8 [https://www.oracle.com/java/technologies/javase/javase-jdk8-downloads.html](https://www.oracle.com/java/technologies/javase/javase-jdk8-downloads.html).
+
+Fixing an issue in a web application
+==================================
+If you are planning to fix an issue in a specific web application, you don't need to build the whole repository. You only need to build that specific application from the portals folder. We will take fixing an issue in publisher web application as an example.
+
+1. If you do not build a WSO2 API Manager server, Download the built distribution of WSO2 API Manager Server from http://wso2.com/api-manager. 
+
+2. Execute api-manager.sh (For unix environment) or api-manager.bat (For windows environment) file from the bin directory to run WSO2 API Manager Server.
+
+3. Goto `portals/publisher` directory in the `apim-apps` repository
+
+4. You can either run `mvn clean install` or `npm ci`. Note that the `npm ci` will be faster since `mvn clean install` command is executing production build and UI tests.
+
+5. Run `npm start` to start publisher portal in development mode.
+
+Now you can update the code to view the changes in the development server. Once you are done with the fixes,
+you can run `npm run build:prod` to check for errors before committing. Also refer to 'Running Tests' section and run test if the tests are effected. At the moment these tests are valid for only publisher app.
+
+### Adding or updating a new dependency
+1. Setup the development environment by following the steps given above.
+
+2. Run the npm command from the web application root folder. ( Ex: For publisher web app, it's portals/publisher ).
+   - Adding a dependency `npm i <package-name>`. (Ex: `npm i base64url`)
+   - Removing a dependency `npm uninstall <package-name>`. (Ex: `npm uninstall base64url`)
+   - Updating a version or specifying version when installing `npm i <package-name>@<version>`. (Ex: `npm i base64url@3.0.1`).
+
+3. Once you successfully run the above commands the package.json and package-lock.json files will be updated. You need to commit both of them. 
+
+>
+> Never run `npm i` since it will update the package lock for all the dependencies with there minor updated versions.
+>
+
+Building & Running
+==================================
+### Build
+ 1. Download or clone the project source code from https://github.com/wso2/apim-apps
+
+ 2. If you want to build all web apps, run `mvn clean install` from the command line in the project root directory (where the root pom.xml is located). 
+
+ 3. Then you just need to build [WSO2 API Manager Server](https://github.com/wso2/product-apim) after. (Follow the guide there)
+
+### Run
+
+4. Extract the wso2am-4.0.0.zip and go to the 'bin' directory
+
+5. Run the api-manager.sh or api-manager.bat script based on you operating system.
+
+6. Access the respective WSO2 API-M interfaces
+    * API Publisher web application is running at - https://localhost:9443/publisher \
+  You may sign in to the Publisher using the default administrator credentials (username: admin, password: admin).
+    * Developer Portal web application is running at - https://localhost:9443/devportal \
+  You may sign in to the Developer Portal using the default administrator credentials (username: admin, password: admin).
+Running Tests
+==================================
+## Unit Tests
+
+Product Unit tests have been implemented using [Jest](https://jestjs.io/) along with [enzyme](https://enzymejs.github.io/enzyme/)
+
+### Run Tests for individual module
+
+- Go to the respective individual portals directory
+
+  i:e `/portals/publisher/`
+- and run
+
+  ```
+  npm run test
+  ```
+  For more information regarding the test module, checkout the [README](./portals/publisher/source/Tests/README.md) in the publisher `Tests` module.
+### Integration Tests
+
+Product integration tests have been written using [Cypress Testing Framework](https://www.cypress.io/) and you can run the test suites using the following command.
+
+- Goto `/tests/cypress/`
+
+#### Headless mode
+
+- Run
+
+  ```
+  npm run test
+  ```
+#### Interactive mode (with GUI)
+
+- Run
+
+  ```
+  npm run test:gui
+  ```
+Support
+==================================
+
+WSO2 Inc. offers a variety of development and production support
+programs, ranging from Web-based support up through normal business
+hours, to premium 24x7 phone support.
+
+For additional support information please refer to http://wso2.com/support
+
+For more information on WSO2 API Manager please visit https://wso2.com/api-management/
+
+Known Issues of WSO2 API Manager
+==================================
+
+All known issues of WSO2 API Manager are filed at:
+   
+* https://github.com/wso2/product-apim/issues
+
+
+--------------------------------------------------------------------------------
+(c) Copyright 2023 WSO2 Inc.

--- a/cypress/integration/devportal/000-general/03-self-signup.spec.js
+++ b/cypress/integration/devportal/000-general/03-self-signup.spec.js
@@ -1,0 +1,160 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import Utils from "@support/utils";
+
+function getSuperTenantEmail(username){
+    return `${username}@test.com`;
+}
+
+describe("Self Signup", () => {
+    const {publisher, password, carbonUsername, carbonPassword} = Utils.getUserInfo();
+    const testTenant = 'wso2.com';
+    const superTenant = 'carbon.super';
+    const devPortal = 'devportal';
+    const adminPortal = 'admin';
+    const firstName = 'firstName';
+    const lastName = 'lastName';
+    const superTenant1Username = 'superTenant1';
+    const superTenant2Username = 'superTenant2'; 
+    const superTenant3Username = 'superTenant3';  
+    const tenant1Username = 'tenant1'; 
+    const tenant2Username = 'tenant2';
+    const tenant3Username = 'tenant3';
+    const incorrectUsername = 'incorrectUsername';
+    const incorrectPassword = 'incorrectPassword';
+    const tenantAdminUsername = 'admin';
+    const tenantAdminPassword = 'admin';
+         
+it.only("Verify default self-signup behaviour of the super tenant", () => {
+    cy.addNewUserUsingSelfSignUp(superTenant1Username, password, firstName, lastName, getSuperTenantEmail(superTenant1Username), superTenant);
+    cy.addExistingUserUsingSelfSignUp(superTenant1Username, superTenant);
+    cy.portalLogin(superTenant1Username, password, superTenant, devPortal);
+    cy.logoutFromDevportal();
+});
+
+it.only("Verify default self-signup behaviour of the wso2 tenant", () => {
+    cy.addNewUserUsingSelfSignUp(Utils.getTenentUser(tenant1Username, testTenant), password, firstName, lastName, Utils.getTenentUser(tenant1Username, testTenant), testTenant);
+    cy.addExistingUserUsingSelfSignUp(Utils.getTenentUser(tenant1Username, testTenant), testTenant);
+    cy.portalLogin(tenant1Username, password, testTenant, devPortal,);
+    cy.logoutFromDevportal();
+});
+
+it.only("Verify login to the devPortal using incorrect user credentials", () => {
+    cy.portalLoginUsingIncorrectUserCredentials(incorrectUsername, incorrectPassword, devPortal, testTenant);
+});
+
+it.only("Test - Login to the publisher portal using incorrect user credentials", () => {
+    cy.portalLoginUsingIncorrectUserCredentials(incorrectUsername, incorrectPassword, publisher, superTenant);
+});
+
+it.only("Test - Login to the admin portal using incorrect user credentials", () => {
+    cy.portalLoginUsingIncorrectUserCredentials(incorrectUsername, incorrectPassword, adminPortal, superTenant);
+});
+
+it.only("Test - Login to the carbon using incorrect user credentials", () => {
+    cy.carbonLogin(incorrectUsername, incorrectPassword);
+    cy.contains('Login failed! Please recheck the username and password and try again.').should('exist');
+});
+
+it.only("Test - Login to the publisher using newly created user(superTenant1) credentials", () => {
+    cy.portalLogin(superTenant1Username, password, superTenant, publisher);
+    cy.contains('Error 403 : Forbidden').should('exist');
+    cy.contains('The server could not verify that you are authorized to access the requested resource.').should('exist');
+    cy.logoutFromPublisher();
+});
+
+it.only("Test - Login to the admin portal using newly created user(superTenant1) credentials", () => {
+    cy.portalLogin(superTenant1Username, password, superTenant, adminPortal);
+    cy.contains('Error 403 : Forbidden').should('exist');
+    cy.contains('The server could not verify that you are authorized to access the requested resource.').should('exist');
+    cy.logoutFromAdminPortal();
+});
+
+it.only("Test - Login to the carbon using newly created user(superTenant1) credentials", () => {
+    cy.carbonLogin(superTenant1Username, password);
+    cy.get('#region1_dashboard_main_menu').should('not.exist');
+    cy.get('#region3_registry_menu').should('not.exist');
+    cy.get('#region3_metadata_menu').should('not.exist');
+    cy.carbonLogout();
+});
+
+it.only("Test - Disable self signup from the carbon portal for the super tenant", () => {
+    cy.disableSelfSignUpInCarbonPortal(carbonUsername, carbonPassword, superTenant);
+    cy.visit(`${Utils.getAppOrigin()}/devportal/apis?tenant=${superTenant}`);
+    cy.get('#itest-devportal-sign-in').click();
+    cy.get('#registerLink').click();
+    cy.get('#username').type(superTenant2Username);
+    cy.get('#registrationSubmit').click();
+    cy.contains(`Self registration is disabled for tenant - ${superTenant}`).should('exist');
+});
+
+it.only("Test - Disable self signup from the carbon portal for the wso2 tenant", () => {
+    cy.disableSelfSignUpInCarbonPortal(tenantAdminUsername, tenantAdminPassword, testTenant);
+    cy.visit(`${Utils.getAppOrigin()}/devportal/apis?tenant=${testTenant}`);
+    cy.get('#itest-devportal-sign-in').click();
+    cy.get('#registerLink').click();
+    cy.get('#username').type(Utils.getTenentUser(tenant2Username, testTenant));
+    cy.get('#registrationSubmit').click();
+    cy.contains(`Self registration is disabled for tenant - ${testTenant}`).should('exist');
+});
+
+it.only("Test - Enable self signup back for the super tenant", () => {
+    cy.enableSelfSignUpInCarbonPortal(carbonUsername, carbonPassword, superTenant);
+    cy.addNewUserUsingSelfSignUp(superTenant3Username, password, firstName, lastName, getSuperTenantEmail(superTenant3Username), superTenant);
+    cy.portalLogin(superTenant3Username, password, superTenant, devPortal,);
+    cy.logoutFromDevportal();
+});
+
+it.only("Test - Enable self signup back for the wso2 tenant", () => {
+    cy.enableSelfSignUpInCarbonPortal(tenantAdminUsername, tenantAdminPassword, testTenant);
+    cy.addNewUserUsingSelfSignUp(Utils.getTenentUser(tenant3Username, testTenant), password, firstName, lastName, Utils.getTenentUser(tenant3Username, testTenant), testTenant);
+    cy.portalLogin(tenant3Username, password, testTenant, devPortal,);
+    cy.logoutFromDevportal();
+});
+
+it.only("Test - Create a user for a unregistered tenant", () => {
+    cy.visit(`${Utils.getAppOrigin()}/devportal/apis?tenant=${testTenant}`);
+    cy.get('#itest-devportal-sign-in').click();
+    cy.get('#registerLink').click();
+    cy.get('#username').type('test@abc.com');
+    cy.get('#registrationSubmit').click();
+    cy.contains(`Invalid tenant domain - abc.com`).should('exist');
+});
+
+after(function () {
+    cy.carbonLogin(carbonUsername, carbonPassword);
+    // delete all the created users for super tenant
+    cy.visit(`${Utils.getAppOrigin()}/carbon/user/user-mgt.jsp`);
+    cy.deleteUser(superTenant1Username);
+    cy.deleteUser(superTenant3Username);
+    cy.carbonLogout();
+
+    cy.carbonLogin(tenantAdminUsername, tenantAdminPassword, testTenant);
+    // delete all the created users for tenant
+    cy.visit(`${Utils.getAppOrigin()}/carbon/user/user-mgt.jsp`);
+    cy.deleteUser(tenant1Username);
+    cy.deleteUser(tenant3Username);
+   
+    // Remove created user roles
+    cy.carbonLogout();
+
+    // Reset all the configs back to ensure default behaviour
+    cy.enableSelfSignUpInCarbonPortal(carbonUsername, carbonPassword, superTenant);
+    cy.enableSelfSignUpInCarbonPortal(tenantAdminUsername, tenantAdminPassword, testTenant);
+})
+
+});


### PR DESCRIPTION
Added self sign up test cases for 4.0.0 UI test suit

Following test cases are included in the spec

1. Verify default self-signup behaviour of the super tenant
2. Verify default self-signup behaviour of the wso2 tenant
3. Verify login to the devPortal using incorrect user credentials
4. Test - Login to the publisher portal using incorrect user credentials
5. Test - Login to the admin portal using incorrect user credentials
6. Test - Login to the carbon using incorrect user credentials
7. Test - Login to the publisher using newly created user(superTenant1) credentials
8. Test - Login to the admin portal using newly created user(superTenant1) credential
9. Test - Login to the carbon using newly created user(superTenant1) credentials
10. Test - Disable self signup from the carbon portal for the super tenant
11. Test - Disable self signup from the carbon portal for the wso2 tenant
12. Test - Enable self signup back for the super tenant
13. Test - Enable self signup back for the wso2 tenant
14. Test - Create a user for a unregistered tenant

Necessary changes have been added to commands.js