### PR TITLE
[4.1.0] Increase delay to 5s after revocation call

### DIFF
--- a/tests-cases/profile-tests/Profile_Setup_Tests.postman_collection.json
+++ b/tests-cases/profile-tests/Profile_Setup_Tests.postman_collection.json
@@ -7061,7 +7061,7 @@
 									"    pm.response.to.have.status(200);",
 									"});",
 									"",
-									"setTimeout(function(){}, 2000);",
+									"setTimeout(function(){}, 5000);",
 									""
 								],
 								"type": "text/javascript"


### PR DESCRIPTION
## Purpose
This PR increases the delay from 2s to 5s after revocation call to fix the intermittent test failure.