### PR TITLE
[4.1.0] Increase the retry count to 10 for API invocation after revocation

### DIFF
--- a/tests-cases/profile-tests/Profile_Setup_Tests.postman_collection.json
+++ b/tests-cases/profile-tests/Profile_Setup_Tests.postman_collection.json
@@ -7360,7 +7360,7 @@
 							"listen": "prerequest",
 							"script": {
 								"exec": [
-									"pm.variables.set(\"retryCount\", 5);",
+									"pm.variables.set(\"retryCount\", 10);",
 									"setTimeout(function(){}, 800);"
 								],
 								"type": "text/javascript"


### PR DESCRIPTION
## Purpose
This PR increases the retry count to 10 for API invocation after revocation.