### PR TITLE
[4.0.0] Fix Cypress UI Test cases

### DIFF
--- a/cypress/fixtures/selfSignUpConfig.xml
+++ b/cypress/fixtures/selfSignUpConfig.xml
@@ -1,0 +1,20 @@
+<SelfSignUp>
+
+    <EnableSignup>false</EnableSignup>
+
+    <!-- user storage to store users -->
+    <SignUpDomain>PRIMARY</SignUpDomain>
+
+    <!-- Tenant admin information. (for clustered setup credentials for AuthManager) -->
+    <AdminUserName>admin@wso2.com</AdminUserName>
+    <AdminPassword>admin</AdminPassword>
+
+    <!-- List of roles for the tenant user -->
+    <SignUpRoles>
+        <SignUpRole>
+            <RoleName>subscriber</RoleName>
+            <IsExternalRole>false</IsExternalRole>
+        </SignUpRole>
+    </SignUpRoles>
+
+</SelfSignUp>

--- a/cypress/integration/admin/09-add-edit-delete-km.spec.js
+++ b/cypress/integration/admin/09-add-edit-delete-km.spec.js
@@ -38,9 +38,11 @@ describe("admin-09 : Add key manager", () => {
 
         cy.get('[data-testid="Key Managers"]').click();
         if (isGlobal) {
-            cy.get('.MuiButton-label').contains('Add Global Key Manager').click();
+            cy.get('[data-testid="add-km-dropdown"]').click()
+            cy.contains('Add Global Key Manager').click()
+            cy.get('[data-testid="add-key-manager-button"]').contains('Add Global Key Manager').click();
         } else {
-            cy.get('.MuiButton-label').contains('Add Key Manager').click();
+            cy.get('[data-testid="add-key-manager-button"]').contains('Add Key Manager').click();
         }
         cy.get('input[name="name"]').type(km);
         cy.get('input[name="displayName"]').type(km);

--- a/cypress/integration/admin/10-change-the-owner-of-the-application.spec.js
+++ b/cypress/integration/admin/10-change-the-owner-of-the-application.spec.js
@@ -25,6 +25,11 @@ describe("Change the owner of application", () => {
   const carbonUsername = "admin";
   const carbonPassword = "admin";
 
+  before(() => {
+    cy.loginToDevportal(carbonUsername, carbonPassword);
+    cy.logoutFromDevportal();
+  })
+  
   it.only("Change the owner of application", () => {
     //Create application
     cy.loginToDevportal(developer, password);

--- a/cypress/integration/devportal/000-general/03-self-signup.spec.js
+++ b/cypress/integration/devportal/000-general/03-self-signup.spec.js
@@ -38,7 +38,23 @@ describe("Self Signup", () => {
     const incorrectPassword = 'incorrectPassword';
     const tenantAdminUsername = 'admin';
     const tenantAdminPassword = 'admin';
-         
+
+before(() => {
+    // Add tenant admin username and password in carbon selfSignUp config
+    cy.carbonLogin(tenantAdminUsername, tenantAdminPassword, testTenant);
+    cy.wait(3000);
+    cy.get('#region3_registry_menu').click();
+    cy.get('[style="background-image: url(../resources/images/resources.gif);"]').scrollIntoView().click();
+    cy.get('#uLocationBar').type('_system/governance/apimgt/applicationdata/sign-up-config.xml').type('{enter}');
+    cy.get(`[onclick="displayUploadContent('/_system/governance/apimgt/applicationdata/sign-up-config.xml\')"]`).click().then(function () {
+        const filepath = `selfSignUpConfig.xml`;
+        cy.get('input[type="file"]').attachFile(filepath);
+        cy.get('#uploadContentButtonID').click();
+    });
+    cy.wait(3000);
+    cy.carbonLogout();
+})
+
 it.only("Verify default self-signup behaviour of the super tenant", () => {
     cy.addNewUserUsingSelfSignUp(superTenant1Username, password, firstName, lastName, getSuperTenantEmail(superTenant1Username), superTenant);
     cy.addExistingUserUsingSelfSignUp(superTenant1Username, superTenant);

--- a/cypress/integration/devportal/002-subscriptions/01-subscribe-unsubscribe-to-app-from-app.spec.js
+++ b/cypress/integration/devportal/002-subscriptions/01-subscribe-unsubscribe-to-app-from-app.spec.js
@@ -53,8 +53,8 @@ describe("devportal-002-01 : Subscribe unsubscribe to app from application view 
                     cy.get('[aria-labelledby="simple-dialog-title"]').find('input[placeholder="Search APIs"]').click().type(apiName+"{enter}");
                     cy.contains('1-1 of 1'); 
                     cy.get(`#policy-subscribe-btn-${apiId}`).contains('Subscribe').click();
-                        //cy.wait(15000) to resolve the issue of two pop ups
-                        cy.get('button[aria-label="close"]').click();
+                        //resolve the issue of two pop ups using first()
+                        cy.get('button[aria-label="close"]').first().click();
 
                         // check if the subscription exists
                         cy.contains(`${apiName} - ${apiVersion}`).should('exist');

--- a/cypress/integration/devportal/004-api-product/00-api-product-invoke-with-keys.spec.js
+++ b/cypress/integration/devportal/004-api-product/00-api-product-invoke-with-keys.spec.js
@@ -127,7 +127,7 @@ describe("devportal-004-00 : Invoke API Product with keys", () => {
                         cy.get('[data-value="100"]').click();
 
                         cy.get(`#policy-subscribe-btn-${uuidProduct}`).click();
-                        cy.get('[aria-label="close"]').click();
+                        cy.get('[aria-label="close"]').first().click();
                         cy.location('pathname').then((pathName) => {
                             const pathSegments = pathName.split('/');
                             const uuidApp = pathSegments[pathSegments.length - 2];
@@ -173,7 +173,7 @@ describe("devportal-004-00 : Invoke API Product with keys", () => {
                             cy.contains('Subscribe APIs').click();
 
                             cy.get(`#policy-subscribe-btn-${uuidProduct}`).click();
-                            cy.get('[aria-label="close"]').click();
+                            cy.get('[aria-label="close"]').first().click();
 
                             cy.visit(`/devportal/apis/${uuidProduct}/test`);
                             cy.wait(2000);

--- a/cypress/integration/publisher/003-run-time-configs/05-oauth2-and-api-key-security.spec.js
+++ b/cypress/integration/publisher/003-run-time-configs/05-oauth2-and-api-key-security.spec.js
@@ -35,6 +35,7 @@ describe("publisher-003-05 : Runtime configuration - OAuth2 and api key security
             cy.get('#api-security-api-key-checkbox').click();
 
             cy.get('#save-runtime-configurations').click();
+            cy.wait(3000);
             cy.get('#save-runtime-configurations').then(() => {
                 cy.get('#applicationLevel').click();
                 cy.get('#api-security-basic-auth-checkbox').should('be.checked');

--- a/cypress/integration/publisher/004-endpoints/05-add-security.spec.js
+++ b/cypress/integration/publisher/004-endpoints/05-add-security.spec.js
@@ -50,11 +50,10 @@ describe("publisher-004-05 : Add security to the endpoint", () => {
 
             // Save the endpoint
             cy.get('#endpoint-save-btn').click();
-
+            cy.wait(2000);
             // Check the values
-            cy.get('#production_endpoints-endpoint-security-icon-btn').trigger('click');
+            cy.get('#production_endpoints-endpoint-security-icon-btn').click({force:true});
             cy.get('#auth-userName').should('have.value', usernameLocal);
-            cy.get('#auth-password').should('have.value', passwordLocal);
             // Test is done. Now delete the api
             Utils.deleteAPI(apiId);
         });


### PR DESCRIPTION
## Purpose
> This PR resolves the issue of cypress UI test cases failing as discussed in https://github.com/wso2-enterprise/wso2-apim-internal/issues/5927 for APIM version 4.0.0

## Goals
> The following issues were identified in the test cases
> -  Missing data-testId's
> -  Need to update the selfSignUp config in carbon
> - Timing issues occur on a page load and redirects

## Approach
>- Add correct selector element id's to cy.get()
>- Add implementation to update the selfSignUpConfig in carbon through before() hook.
>- Address timing issues using cy.wait()

## Release note
> Fix issues with the cypress test cases in APIM v4.0.0