### PR TITLE
Update Error Status to 500 for invalid response body

### DIFF
--- a/tests-cases/profile-tests/Profile_Setup_Tests.postman_collection.json
+++ b/tests-cases/profile-tests/Profile_Setup_Tests.postman_collection.json
@@ -3109,7 +3109,7 @@
 								"exec": [
 									"// Assert the response code",
 									"pm.test(\"Invoke API with invalid response body\", function () {",
-									"    pm.response.to.have.status(400);",
+									"    pm.response.to.have.status(500);",
 									"});",
 									"",
 									"var apiResponse = pm.response.text();",


### PR DESCRIPTION
## Purpose
$subject 

## Related Issue
https://github.com/wso2-enterprise/wso2-apim-internal/issues/10076

## Approach
Updated the error code from previous 400 to 500 during assertion.
