### PR TITLE
4.4.0 profile automation parallel builds

### DIFF
--- a/cleanup.sh
+++ b/cleanup.sh
@@ -29,8 +29,7 @@ echo "Uninstalling APIM in cluster."
 helm uninstall "${product_name}" -n="${kubernetes_namespace}" || true
 
 echo "Delete fargate profile."
-temp_product_version=$(echo "${product_version}" | tr '.' '_') # Fargate profile name does not support '.' character.
-eksctl delete fargateprofile  --name "${product_name}-${temp_product_version}-fargate-profile" --cluster "${EKS_CLUSTER_NAME}" --region ${EKS_CLUSTER_REGION}
+eksctl delete fargateprofile  --name "${product_name}-${SHORT_PRODUCT_VERSION}-fargate-profile" --cluster "${EKS_CLUSTER_NAME}" --region ${EKS_CLUSTER_REGION}
 
 cd "$workingdir"
 

--- a/cleanup.sh
+++ b/cleanup.sh
@@ -29,7 +29,8 @@ echo "Uninstalling APIM in cluster."
 helm uninstall "${product_name}" -n="${kubernetes_namespace}" || true
 
 echo "Delete fargate profile."
-eksctl delete fargateprofile  --name "${product_name}-${product_version}-fargate-profile" --cluster "${EKS_CLUSTER_NAME}" --region ${EKS_CLUSTER_REGION}
+temp_product_version=$(echo "${product_version}" | tr '.' '_') # Fargate profile name does not support '.' character.
+eksctl delete fargateprofile  --name "${product_name}-${temp_product_version}-fargate-profile" --cluster "${EKS_CLUSTER_NAME}" --region ${EKS_CLUSTER_REGION}
 
 cd "$workingdir"
 

--- a/cleanup.sh
+++ b/cleanup.sh
@@ -29,7 +29,7 @@ echo "Uninstalling APIM in cluster."
 helm uninstall "${product_name}" -n="${kubernetes_namespace}" || true
 
 echo "Delete fargate profile."
-eksctl delete fargateprofile  --name "${product_name}-fargate-profile" --cluster "${EKS_CLUSTER_NAME}" --region ${EKS_CLUSTER_REGION}
+eksctl delete fargateprofile  --name "${product_name}-${product_version}-fargate-profile" --cluster "${EKS_CLUSTER_NAME}" --region ${EKS_CLUSTER_REGION}
 
 cd "$workingdir"
 

--- a/deploy.sh
+++ b/deploy.sh
@@ -199,6 +199,7 @@ helm install apim "kubernetes-apim/${path_to_helm_folder}" \
     --set wso2.deployment.am.cp.db.apim_shared.password="$dbPasswordAPIMShared" \
     --set wso2.deployment.am.cp.db.apim.url="$dbAPIMUrl" \
     --set wso2.deployment.am.cp.db.apim_shared.url="$dbAPIMSharedUrl" \
+    --set wso2.deployment.am.cp.ingress.hostname="am-${product_version}.wso2.com" \
     --set wso2.deployment.dependencies.cluster_mysql=false \
     --set wso2.deployment.am.trafficmanager.livenessProbe.initialDelaySeconds=180 \
     --set wso2.deployment.am.trafficmanager.readinessProbe.initialDelaySeconds=180 \
@@ -207,6 +208,7 @@ helm install apim "kubernetes-apim/${path_to_helm_folder}" \
     --set wso2.deployment.am.startupProbe.initialDelaySeconds=180 \
     --set wso2.deployment.am.startupProbe.periodSeconds=10 \
     --set wso2.deployment.am.readinessProbe.initialDelaySeconds=180 \
+    --set wso2.deployment.am.gateway.ingress.hostname="gateway.am-${product_version}.wso2.com" \
     --set wso2.deployment.dependencies.nfsServerProvisioner=false \
     --set wso2.deployment.mi.replicas=0 \
     --set wso2.deployment.am.gateway.replicas=1 \

--- a/deploy.sh
+++ b/deploy.sh
@@ -95,11 +95,17 @@ aws eks update-kubeconfig --region ${EKS_CLUSTER_REGION} --name ${EKS_CLUSTER_NA
 # Create fargate profile
 eksctl create fargateprofile --cluster "${EKS_CLUSTER_NAME}" --name "${product_name}-${SHORT_PRODUCT_VERSION}-fargate-profile" --namespace "${kubernetes_namespace}" --region ${EKS_CLUSTER_REGION} || { echo "Failed to create fargate profile." ; exit 1 ; }
 
-# Install nginx ingress controller
-kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/controller-v1.0.4/deploy/static/provider/aws/deploy.yaml || { echo "failed to install nginx ingress controller." ; exit 1 ; }
+# Check if nginx ingress controller exists
+if ! kubectl get deployment -n ingress-nginx ingress-nginx-controller &> /dev/null; then
+    echo "Nginx ingress controller not found. Installing..."
+    # Install nginx ingress controller
+    kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/controller-v1.0.4/deploy/static/provider/aws/deploy.yaml || { echo "failed to install nginx ingress controller." ; exit 1 ; }
 
-# Delete Nginx admission if it exists.
-kubectl delete -A ValidatingWebhookConfiguration ingress-nginx-admission || echo "WARNING : Failed to delete nginx admission."
+    # Delete Nginx admission if it exists.
+    kubectl delete -A ValidatingWebhookConfiguration ingress-nginx-admission || echo "WARNING : Failed to delete nginx admission."
+else
+    echo "Nginx ingress controller already exists. Skipping installation."
+fi
 
 # Extract DB port and DB host name detail.
 dbPort=$(aws cloudformation describe-stacks --stack-name "${RDS_STACK_NAME}" --region "${EKS_CLUSTER_REGION}" --query 'Stacks[?StackName==`'$RDS_STACK_NAME'`][].Outputs[?OutputKey==`TestgridDBJDBCPort`].OutputValue' --output text | xargs)

--- a/deploy.sh
+++ b/deploy.sh
@@ -108,7 +108,8 @@ else
 fi
 
 # Create fargate profile
-eksctl create fargateprofile --cluster "${EKS_CLUSTER_NAME}" --name "${product_name}-${product_version}-fargate-profile" --namespace "${kubernetes_namespace}" --region ${EKS_CLUSTER_REGION} || { echo "Failed to create fargate profile." ; exit 1 ; }
+temp_product_version=$(echo "${product_version}" | tr '.' '_') # Fargate profile name does not support '.' character.
+eksctl create fargateprofile --cluster "${EKS_CLUSTER_NAME}" --name "${product_name}-${temp_product_version}-fargate-profile" --namespace "${kubernetes_namespace}" --region ${EKS_CLUSTER_REGION} || { echo "Failed to create fargate profile." ; exit 1 ; }
 
 # Extract DB port and DB host name detail.
 dbPort=$(aws cloudformation describe-stacks --stack-name "${RDS_STACK_NAME}" --region "${EKS_CLUSTER_REGION}" --query 'Stacks[?StackName==`'$RDS_STACK_NAME'`][].Outputs[?OutputKey==`TestgridDBJDBCPort`].OutputValue' --output text | xargs)

--- a/deploy.sh
+++ b/deploy.sh
@@ -93,7 +93,7 @@ wget -O "./${db_engine}/apim.sql" "https://raw.githubusercontent.com/wso2/apim-t
 aws eks update-kubeconfig --region ${EKS_CLUSTER_REGION} --name ${EKS_CLUSTER_NAME} || { echo 'Failed to update cluster kube config.';  exit 1; }
 
 # Scale node group with one EC2 instance.
-eksctl scale nodegroup --region ${EKS_CLUSTER_REGION} --cluster ${EKS_CLUSTER_NAME} --name ng-1 --nodes=1 || { echo 'Failed to scale the node group.';  exit 1; }
+# eksctl scale nodegroup --region ${EKS_CLUSTER_REGION} --cluster ${EKS_CLUSTER_NAME} --name ng-1 --nodes=1 || { echo 'Failed to scale the node group.';  exit 1; }
 
 # Check if nginx ingress controller exists
 if ! kubectl get deployment -n ingress-nginx ingress-nginx-controller &> /dev/null; then

--- a/deploy.sh
+++ b/deploy.sh
@@ -92,8 +92,8 @@ wget -O "./${db_engine}/apim.sql" "https://raw.githubusercontent.com/wso2/apim-t
 # Update kube config file.
 aws eks update-kubeconfig --region ${EKS_CLUSTER_REGION} --name ${EKS_CLUSTER_NAME} || { echo 'Failed to update cluster kube config.';  exit 1; }
 
-# Scale node group with one EC2 instance.
-eksctl scale nodegroup --region ${EKS_CLUSTER_REGION} --cluster ${EKS_CLUSTER_NAME} --name ng-1 --nodes=1 || { echo 'Failed to scale the node group.';  exit 1; }
+# Create fargate profile
+eksctl create fargateprofile --cluster "${EKS_CLUSTER_NAME}" --name "${product_name}-${SHORT_PRODUCT_VERSION}-fargate-profile" --namespace "${kubernetes_namespace}" --region ${EKS_CLUSTER_REGION} || { echo "Failed to create fargate profile." ; exit 1 ; }
 
 # Check if nginx ingress controller exists
 if ! kubectl get deployment -n ingress-nginx ingress-nginx-controller &> /dev/null; then
@@ -106,9 +106,6 @@ if ! kubectl get deployment -n ingress-nginx ingress-nginx-controller &> /dev/nu
 else
     echo "Nginx ingress controller already exists. Skipping installation."
 fi
-
-# Create fargate profile
-eksctl create fargateprofile --cluster "${EKS_CLUSTER_NAME}" --name "${product_name}-${SHORT_PRODUCT_VERSION}-fargate-profile" --namespace "${kubernetes_namespace}" --region ${EKS_CLUSTER_REGION} || { echo "Failed to create fargate profile." ; exit 1 ; }
 
 # Extract DB port and DB host name detail.
 dbPort=$(aws cloudformation describe-stacks --stack-name "${RDS_STACK_NAME}" --region "${EKS_CLUSTER_REGION}" --query 'Stacks[?StackName==`'$RDS_STACK_NAME'`][].Outputs[?OutputKey==`TestgridDBJDBCPort`].OutputValue' --output text | xargs)

--- a/deploy.sh
+++ b/deploy.sh
@@ -92,6 +92,9 @@ wget -O "./${db_engine}/apim.sql" "https://raw.githubusercontent.com/wso2/apim-t
 # Update kube config file.
 aws eks update-kubeconfig --region ${EKS_CLUSTER_REGION} --name ${EKS_CLUSTER_NAME} || { echo 'Failed to update cluster kube config.';  exit 1; }
 
+# Scale node group with one EC2 instance.
+eksctl scale nodegroup --region ${EKS_CLUSTER_REGION} --cluster ${EKS_CLUSTER_NAME} --name ng-1 --nodes=1 || { echo 'Failed to scale the node group.';  exit 1; }
+
 # Check if nginx ingress controller exists
 if ! kubectl get deployment -n ingress-nginx ingress-nginx-controller &> /dev/null; then
     echo "Nginx ingress controller not found. Installing..."

--- a/deploy.sh
+++ b/deploy.sh
@@ -102,7 +102,7 @@ kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/cont
 kubectl delete -A ValidatingWebhookConfiguration ingress-nginx-admission || echo "WARNING : Failed to delete nginx admission."
 
 # Create fargate profile
-eksctl create fargateprofile --cluster "${EKS_CLUSTER_NAME}" --name "${product_name}-fargate-profile" --namespace "${kubernetes_namespace}" --region ${EKS_CLUSTER_REGION} || { echo "Failed to create fargate profile." ; exit 1 ; }
+eksctl create fargateprofile --cluster "${EKS_CLUSTER_NAME}" --name "${product_name}-${product_version}-fargate-profile" --namespace "${kubernetes_namespace}" --region ${EKS_CLUSTER_REGION} || { echo "Failed to create fargate profile." ; exit 1 ; }
 
 # Extract DB port and DB host name detail.
 dbPort=$(aws cloudformation describe-stacks --stack-name "${RDS_STACK_NAME}" --region "${EKS_CLUSTER_REGION}" --query 'Stacks[?StackName==`'$RDS_STACK_NAME'`][].Outputs[?OutputKey==`TestgridDBJDBCPort`].OutputValue' --output text | xargs)

--- a/deploy.sh
+++ b/deploy.sh
@@ -108,8 +108,7 @@ else
 fi
 
 # Create fargate profile
-temp_product_version=$(echo "${product_version}" | tr '.' '_') # Fargate profile name does not support '.' character.
-eksctl create fargateprofile --cluster "${EKS_CLUSTER_NAME}" --name "${product_name}-${temp_product_version}-fargate-profile" --namespace "${kubernetes_namespace}" --region ${EKS_CLUSTER_REGION} || { echo "Failed to create fargate profile." ; exit 1 ; }
+eksctl create fargateprofile --cluster "${EKS_CLUSTER_NAME}" --name "${product_name}-${SHORT_PRODUCT_VERSION}-fargate-profile" --namespace "${kubernetes_namespace}" --region ${EKS_CLUSTER_REGION} || { echo "Failed to create fargate profile." ; exit 1 ; }
 
 # Extract DB port and DB host name detail.
 dbPort=$(aws cloudformation describe-stacks --stack-name "${RDS_STACK_NAME}" --region "${EKS_CLUSTER_REGION}" --query 'Stacks[?StackName==`'$RDS_STACK_NAME'`][].Outputs[?OutputKey==`TestgridDBJDBCPort`].OutputValue' --output text | xargs)
@@ -200,7 +199,7 @@ helm install apim "kubernetes-apim/${path_to_helm_folder}" \
     --set wso2.deployment.am.cp.db.apim_shared.password="$dbPasswordAPIMShared" \
     --set wso2.deployment.am.cp.db.apim.url="$dbAPIMUrl" \
     --set wso2.deployment.am.cp.db.apim_shared.url="$dbAPIMSharedUrl" \
-    --set wso2.deployment.am.cp.ingress.hostname="am-${product_version}.wso2.com" \
+    --set wso2.deployment.am.cp.ingress.hostname="am-${SHORT_PRODUCT_VERSION}.wso2.com" \
     --set wso2.deployment.dependencies.cluster_mysql=false \
     --set wso2.deployment.am.trafficmanager.livenessProbe.initialDelaySeconds=180 \
     --set wso2.deployment.am.trafficmanager.readinessProbe.initialDelaySeconds=180 \
@@ -209,7 +208,7 @@ helm install apim "kubernetes-apim/${path_to_helm_folder}" \
     --set wso2.deployment.am.startupProbe.initialDelaySeconds=180 \
     --set wso2.deployment.am.startupProbe.periodSeconds=10 \
     --set wso2.deployment.am.readinessProbe.initialDelaySeconds=180 \
-    --set wso2.deployment.am.gateway.ingress.hostname="gateway.am-${product_version}.wso2.com" \
+    --set wso2.deployment.am.gateway.ingress.hostname="gateway.am-${SHORT_PRODUCT_VERSION}.wso2.com" \
     --set wso2.deployment.dependencies.nfsServerProvisioner=false \
     --set wso2.deployment.mi.replicas=0 \
     --set wso2.deployment.am.gateway.replicas=1 \

--- a/deploy.sh
+++ b/deploy.sh
@@ -92,9 +92,6 @@ wget -O "./${db_engine}/apim.sql" "https://raw.githubusercontent.com/wso2/apim-t
 # Update kube config file.
 aws eks update-kubeconfig --region ${EKS_CLUSTER_REGION} --name ${EKS_CLUSTER_NAME} || { echo 'Failed to update cluster kube config.';  exit 1; }
 
-# Scale node group with one EC2 instance.
-# eksctl scale nodegroup --region ${EKS_CLUSTER_REGION} --cluster ${EKS_CLUSTER_NAME} --name ng-1 --nodes=1 || { echo 'Failed to scale the node group.';  exit 1; }
-
 # Check if nginx ingress controller exists
 if ! kubectl get deployment -n ingress-nginx ingress-nginx-controller &> /dev/null; then
     echo "Nginx ingress controller not found. Installing..."

--- a/deploy.sh
+++ b/deploy.sh
@@ -95,11 +95,17 @@ aws eks update-kubeconfig --region ${EKS_CLUSTER_REGION} --name ${EKS_CLUSTER_NA
 # Scale node group with one EC2 instance.
 eksctl scale nodegroup --region ${EKS_CLUSTER_REGION} --cluster ${EKS_CLUSTER_NAME} --name ng-1 --nodes=1 || { echo 'Failed to scale the node group.';  exit 1; }
 
-# Install nginx ingress controller
-kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/controller-v1.0.4/deploy/static/provider/aws/deploy.yaml || { echo "failed to install nginx ingress controller." ; exit 1 ; }
+# Check if nginx ingress controller exists
+if ! kubectl get deployment -n ingress-nginx ingress-nginx-controller &> /dev/null; then
+    echo "Nginx ingress controller not found. Installing..."
+    # Install nginx ingress controller
+    kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/controller-v1.0.4/deploy/static/provider/aws/deploy.yaml || { echo "failed to install nginx ingress controller." ; exit 1 ; }
 
-# Delete Nginx admission if it exists.
-kubectl delete -A ValidatingWebhookConfiguration ingress-nginx-admission || echo "WARNING : Failed to delete nginx admission."
+    # Delete Nginx admission if it exists.
+    kubectl delete -A ValidatingWebhookConfiguration ingress-nginx-admission || echo "WARNING : Failed to delete nginx admission."
+else
+    echo "Nginx ingress controller already exists. Skipping installation."
+fi
 
 # Create fargate profile
 eksctl create fargateprofile --cluster "${EKS_CLUSTER_NAME}" --name "${product_name}-${product_version}-fargate-profile" --namespace "${kubernetes_namespace}" --region ${EKS_CLUSTER_REGION} || { echo "Failed to create fargate profile." ; exit 1 ; }

--- a/deploy.sh
+++ b/deploy.sh
@@ -92,8 +92,8 @@ wget -O "./${db_engine}/apim.sql" "https://raw.githubusercontent.com/wso2/apim-t
 # Update kube config file.
 aws eks update-kubeconfig --region ${EKS_CLUSTER_REGION} --name ${EKS_CLUSTER_NAME} || { echo 'Failed to update cluster kube config.';  exit 1; }
 
-# Create fargate profile
-eksctl create fargateprofile --cluster "${EKS_CLUSTER_NAME}" --name "${product_name}-${SHORT_PRODUCT_VERSION}-fargate-profile" --namespace "${kubernetes_namespace}" --region ${EKS_CLUSTER_REGION} || { echo "Failed to create fargate profile." ; exit 1 ; }
+# Scale node group with one EC2 instance.
+eksctl scale nodegroup --region ${EKS_CLUSTER_REGION} --cluster ${EKS_CLUSTER_NAME} --name ng-1 --nodes=1 || { echo 'Failed to scale the node group.';  exit 1; }
 
 # Check if nginx ingress controller exists
 if ! kubectl get deployment -n ingress-nginx ingress-nginx-controller &> /dev/null; then
@@ -106,6 +106,9 @@ if ! kubectl get deployment -n ingress-nginx ingress-nginx-controller &> /dev/nu
 else
     echo "Nginx ingress controller already exists. Skipping installation."
 fi
+
+# Create fargate profile
+eksctl create fargateprofile --cluster "${EKS_CLUSTER_NAME}" --name "${product_name}-${SHORT_PRODUCT_VERSION}-fargate-profile" --namespace "${kubernetes_namespace}" --region ${EKS_CLUSTER_REGION} || { echo "Failed to create fargate profile." ; exit 1 ; }
 
 # Extract DB port and DB host name detail.
 dbPort=$(aws cloudformation describe-stacks --stack-name "${RDS_STACK_NAME}" --region "${EKS_CLUSTER_REGION}" --query 'Stacks[?StackName==`'$RDS_STACK_NAME'`][].Outputs[?OutputKey==`TestgridDBJDBCPort`].OutputValue' --output text | xargs)

--- a/deploy.sh
+++ b/deploy.sh
@@ -95,17 +95,11 @@ aws eks update-kubeconfig --region ${EKS_CLUSTER_REGION} --name ${EKS_CLUSTER_NA
 # Create fargate profile
 eksctl create fargateprofile --cluster "${EKS_CLUSTER_NAME}" --name "${product_name}-${SHORT_PRODUCT_VERSION}-fargate-profile" --namespace "${kubernetes_namespace}" --region ${EKS_CLUSTER_REGION} || { echo "Failed to create fargate profile." ; exit 1 ; }
 
-# Check if nginx ingress controller exists
-if ! kubectl get deployment -n ingress-nginx ingress-nginx-controller &> /dev/null; then
-    echo "Nginx ingress controller not found. Installing..."
-    # Install nginx ingress controller
-    kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/controller-v1.0.4/deploy/static/provider/aws/deploy.yaml || { echo "failed to install nginx ingress controller." ; exit 1 ; }
+# Install nginx ingress controller
+kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/controller-v1.0.4/deploy/static/provider/aws/deploy.yaml || { echo "failed to install nginx ingress controller." ; exit 1 ; }
 
-    # Delete Nginx admission if it exists.
-    kubectl delete -A ValidatingWebhookConfiguration ingress-nginx-admission || echo "WARNING : Failed to delete nginx admission."
-else
-    echo "Nginx ingress controller already exists. Skipping installation."
-fi
+# Delete Nginx admission if it exists.
+kubectl delete -A ValidatingWebhookConfiguration ingress-nginx-admission || echo "WARNING : Failed to delete nginx admission."
 
 # Extract DB port and DB host name detail.
 dbPort=$(aws cloudformation describe-stacks --stack-name "${RDS_STACK_NAME}" --region "${EKS_CLUSTER_REGION}" --query 'Stacks[?StackName==`'$RDS_STACK_NAME'`][].Outputs[?OutputKey==`TestgridDBJDBCPort`].OutputValue' --output text | xargs)

--- a/main.sh
+++ b/main.sh
@@ -81,8 +81,8 @@ operation_policy_file_path="$tests_dir/tests-cases/profile-tests/resources/opera
   --env-var "cluster_ip=${HOST_NAME}" \
   --env-var "pizzashack_endpoint=https://wso2am-pattern-4-am-cp-service:9443/am/sample/pizzashack/v1/api/" \
   --env-var "operation_policy_file_path=$operation_policy_file_path" \
-  --env-var "portals_host=am-${product_version}.wso2.com" \
-  --env-var "gateway_host=gateway.am-${product_version}.wso2.com" \
+  --env-var "portals_host=am-${SHORT_PRODUCT_VERSION}.wso2.com" \
+  --env-var "gateway_host=gateway.am-${SHORT_PRODUCT_VERSION}.wso2.com" \
   --insecure \
   --reporters cli,junit \
   --reporter-junit-export newman-profile-results.xml

--- a/main.sh
+++ b/main.sh
@@ -81,6 +81,8 @@ operation_policy_file_path="$tests_dir/tests-cases/profile-tests/resources/opera
   --env-var "cluster_ip=${HOST_NAME}" \
   --env-var "pizzashack_endpoint=https://wso2am-pattern-4-am-cp-service:9443/am/sample/pizzashack/v1/api/" \
   --env-var "operation_policy_file_path=$operation_policy_file_path" \
+  --env-var "portals_host=am-${product_version}.wso2.com" \
+  --env-var "gateway_host=gateway.am-${product_version}.wso2.com" \
   --insecure \
   --reporters cli,junit \
   --reporter-junit-export newman-profile-results.xml


### PR DESCRIPTION
## Purpose
Currently, when running profile tests for version 4.4.0 and below, it is not possible to run multiple builds in parallel because they use the same ingress names and Fargate profile. This PR addresses that issue.

## Goals
Separate handle cloud resources for each version.

## Approach
- Create ingress only if not exists 
- Separate ingress resources 
- Change fargate profile name
