### PR TITLE
3.2.1 Seperate profiles

### DIFF
--- a/cleanup.sh
+++ b/cleanup.sh
@@ -29,7 +29,6 @@ echo "Uninstalling APIM in cluster."
 helm uninstall "${product_name}" -n="${kubernetes_namespace}" || true
 
 echo "Delete fargate profile."
-eksctl delete fargateprofile  --name "${product_name}-fargate-profile" --cluster "${EKS_CLUSTER_NAME}" --region ${EKS_CLUSTER_REGION}
-
+eksctl delete fargateprofile  --name "${product_name}-${SHORT_PRODUCT_VERSION}-fargate-profile" --cluster "${EKS_CLUSTER_NAME}" --region ${EKS_CLUSTER_REGION}
 cd "$workingdir"
 

--- a/deploy.sh
+++ b/deploy.sh
@@ -91,6 +91,9 @@ aws s3 cp "s3://test-grid-apim/profile-automation/apim/${product_version}/${db_e
 # Update kube config file.
 aws eks update-kubeconfig --region ${EKS_CLUSTER_REGION} --name ${EKS_CLUSTER_NAME} || { echo 'Failed to update cluster kube config.';  exit 1; }
 
+# Scale node group with one EC2 instance.
+eksctl scale nodegroup --region ${EKS_CLUSTER_REGION} --cluster ${EKS_CLUSTER_NAME} --name ng-1 --nodes=1 || { echo 'Failed to scale the node group.';  exit 1; }
+
 # Check if nginx ingress controller exists
 if ! kubectl get deployment -n ingress-nginx ingress-nginx-controller &> /dev/null; then
     echo "Nginx ingress controller not found. Installing..."

--- a/deploy.sh
+++ b/deploy.sh
@@ -91,17 +91,20 @@ aws s3 cp "s3://test-grid-apim/profile-automation/apim/${product_version}/${db_e
 # Update kube config file.
 aws eks update-kubeconfig --region ${EKS_CLUSTER_REGION} --name ${EKS_CLUSTER_NAME} || { echo 'Failed to update cluster kube config.';  exit 1; }
 
-# Scale node group with one EC2 instance.
-eksctl scale nodegroup --region ${EKS_CLUSTER_REGION} --cluster ${EKS_CLUSTER_NAME} --name ng-1 --nodes=1 || { echo 'Failed to scale the node group.';  exit 1; }
+# Check if nginx ingress controller exists
+if ! kubectl get deployment -n ingress-nginx ingress-nginx-controller &> /dev/null; then
+    echo "Nginx ingress controller not found. Installing..."
+    # Install nginx ingress controller
+    kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/controller-v1.0.4/deploy/static/provider/aws/deploy.yaml || { echo "failed to install nginx ingress controller." ; exit 1 ; }
 
-# Install nginx ingress controller
-kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/controller-v1.0.4/deploy/static/provider/aws/deploy.yaml || { echo "failed to install nginx ingress controller." ; exit 1 ; }
-
-# Delete Nginx admission if it exists.
-kubectl delete -A ValidatingWebhookConfiguration ingress-nginx-admission || echo "WARNING : Failed to delete nginx admission."
+    # Delete Nginx admission if it exists.
+    kubectl delete -A ValidatingWebhookConfiguration ingress-nginx-admission || echo "WARNING : Failed to delete nginx admission."
+else
+    echo "Nginx ingress controller already exists. Skipping installation."
+fi
 
 # Create fargate profile
-eksctl create fargateprofile --cluster "${EKS_CLUSTER_NAME}" --name "${product_name}-fargate-profile" --namespace "${kubernetes_namespace}" --region ${EKS_CLUSTER_REGION} || { echo "Failed to create fargate profile." ; exit 1 ; }
+eksctl create fargateprofile --cluster "${EKS_CLUSTER_NAME}" --name "${product_name}-${SHORT_PRODUCT_VERSION}-fargate-profile" --namespace "${kubernetes_namespace}" --region ${EKS_CLUSTER_REGION} || { echo "Failed to create fargate profile." ; exit 1 ; }
 
 # Extract DB port and DB host name detail.
 dbPort=$(aws cloudformation describe-stacks --stack-name "${RDS_STACK_NAME}" --region "${EKS_CLUSTER_REGION}" --query 'Stacks[?StackName==`'$RDS_STACK_NAME'`][].Outputs[?OutputKey==`TestgridDBJDBCPort`].OutputValue' --output text | xargs)
@@ -225,9 +228,11 @@ helm install apim \
     --set wso2.deployment.analytics.db.persistence_db.password="wso2carbon" \
     --set wso2.deployment.analytics.db.persistence_db.url='jdbc:h2:\${sys:carbon.home}/wso2/${sys:wso2.runtime}/database/PERSISTENCE_DB;DB_CLOSE_ON_EXIT=FALSE;LOCK_TIMEOUT=60000;AUTO_SERVER=TRUE' \
     --set wso2.deployment.am.gateway.readinessProbe.initialDelaySeconds=300 \
+    --set wso2.deployment.am.gateway.ingress.hostname="gateway.am-${SHORT_PRODUCT_VERSION}.wso2.com" \
     --set wso2.deployment.am.gateway.livenessProbe.initialDelaySeconds=300 \
     --set wso2.deployment.am.km.readinessProbe.initialDelaySeconds=300 \
     --set wso2.deployment.am.km.livenessProbe.initialDelaySeconds=300 \
+    --set wso2.deployment.am.pubDevPortalTM.ingress.hostname="am-${SHORT_PRODUCT_VERSION}.wso2.com" \
     --set wso2.deployment.analytics.worker.readinessProbe.initialDelaySeconds=60 \
     --set wso2.deployment.analytics.worker.livenessProbe.initialDelaySeconds=60 \
     ||  { echo 'Error while installing APIM to cluster.';  exit 1; }

--- a/main.sh
+++ b/main.sh
@@ -90,6 +90,8 @@ environment_file=$tests_dir/tests-cases/profile-tests/APIM_Environment.postman_e
 /home/ubuntu/.nvm/versions/node/v19.0.1/bin/newman run "$collection_file" \
   --environment "$environment_file" \
   --env-var "cluster_ip=${HOST_NAME}" \
+  --env-var "portals_host=am-${SHORT_PRODUCT_VERSION}.wso2.com" \
+  --env-var "gateway_host=gateway.am-${SHORT_PRODUCT_VERSION}.wso2.com" \
   --insecure \
   --reporters cli,junit \
   --reporter-junit-export newman-profile-results.xml

--- a/main.sh
+++ b/main.sh
@@ -77,6 +77,8 @@ analytics_environment_file=$tests_dir/tests-cases/analytics-tests/analytics_envi
 /home/ubuntu/.nvm/versions/node/v19.0.1/bin/newman run "$analytics_collection_file" \
   --environment "$analytics_environment_file" \
   --env-var "cluster_ip=${HOST_NAME}" \
+  --env-var "portals_host=am-${SHORT_PRODUCT_VERSION}.wso2.com" \
+  --env-var "gateway_host=gateway.am-${SHORT_PRODUCT_VERSION}.wso2.com" \
   --insecure \
   --reporters cli,junit \
   --reporter-junit-export newman-analytics-results.xml


### PR DESCRIPTION
## Purpose
Currently, when running profile tests for version 4.4.0 and below, it is not possible to run multiple builds in parallel because they use the same ingress names and Fargate profile. This PR addresses that issue.

## Goals
Separate handle cloud resources for each version.

## Approach
- Create ingress only if not exists 
- Separate ingress resources 
- Change fargate profile name
