### PR TITLE
Enhance self-update handling in WSO2 update scripts

### DIFF
--- a/resources/advanced/am-pattern-4/templates/am/control-plane/wso2am-pattern-4-am-control-plane-entrypoint.yaml
+++ b/resources/advanced/am-pattern-4/templates/am/control-plane/wso2am-pattern-4-am-control-plane-entrypoint.yaml
@@ -59,13 +59,14 @@ data:
     echo "========================================== update product =========================================================="
     echo "Updating apim to $WSO2_UPDATES_UPDATE_LEVEL_STATE pack ............."
     cd ${WSO2_SERVER_HOME}/bin/
+    set +e
     ./wso2update_linux --backup /home/wso2carbon/ --username {{ .Values.wso2.subscription.username }} --password {{ .Values.wso2.subscription.password }}
-    update_exit_code=$(echo $?)
+    update_exit_code=$?
+    set -e
 
     if [ $update_exit_code -eq 2 ]; then
       echo "Self Update."
       ./wso2update_linux --backup /home/wso2carbon/ --username {{ .Values.wso2.subscription.username }} --password {{ .Values.wso2.subscription.password }}
-      update_exit_code=$(echo $?)
     fi
     
     # log update ids

--- a/resources/advanced/am-pattern-4/templates/am/gateway/wso2am-pattern-4-am-gateway-conf-entrypoint.yaml
+++ b/resources/advanced/am-pattern-4/templates/am/gateway/wso2am-pattern-4-am-gateway-conf-entrypoint.yaml
@@ -59,7 +59,15 @@ data:
     echo "========================================== update product =========================================================="
     echo "Updating apim to $WSO2_UPDATES_UPDATE_LEVEL_STATE pack ............."
     cd ${WSO2_SERVER_HOME}/bin/
+    set +e
     ./wso2update_linux --backup /home/wso2carbon/ --username {{ .Values.wso2.subscription.username }} --password {{ .Values.wso2.subscription.password }}
+    update_exit_code=$?
+    set -e
+
+    if [ $update_exit_code -eq 2 ]; then
+      echo "Self Update."
+      ./wso2update_linux --backup /home/wso2carbon/ --username {{ .Values.wso2.subscription.username }} --password {{ .Values.wso2.subscription.password }}
+    fi
 
     # log update ids
     log_directory="../updates/logs"

--- a/resources/advanced/am-pattern-4/templates/am/traffic-manager/wso2am-pattern-4-am-trafficmanager-entrypoint.yaml
+++ b/resources/advanced/am-pattern-4/templates/am/traffic-manager/wso2am-pattern-4-am-trafficmanager-entrypoint.yaml
@@ -59,7 +59,15 @@ data:
     echo "========================================== update product =========================================================="
     echo "Updating apim to $WSO2_UPDATES_UPDATE_LEVEL_STATE pack ............."
     cd ${WSO2_SERVER_HOME}/bin/
+    set +e
     ./wso2update_linux --backup /home/wso2carbon/ --username {{ .Values.wso2.subscription.username }} --password {{ .Values.wso2.subscription.password }}
+    update_exit_code=$?
+    set -e
+
+    if [ $update_exit_code -eq 2 ]; then
+      echo "Self Update."
+      ./wso2update_linux --backup /home/wso2carbon/ --username {{ .Values.wso2.subscription.username }} --password {{ .Values.wso2.subscription.password }}
+    fi
 
     # log update ids
     log_directory="../updates/logs"


### PR DESCRIPTION
## Purpose
The current `wso2update_linux` script runs only once. As a result, if the update tool itself has an update, the script fails and exits with error code `2`.

## Goals
Ensure the update script runs twice to handle update tool upgrades.

## Approach
Re-run the update script if it exits with code `2`, indicating the update tool was updated and needs to run again.
