### PR TITLE
[4.1.0-profile-automation] Updating log4j.yaml file

### DIFF
--- a/resources/advanced/am-pattern-4/log4j.yaml
+++ b/resources/advanced/am-pattern-4/log4j.yaml
@@ -131,14 +131,14 @@
     appender.ERROR_LOGFILE.filter.threshold.type = ThresholdFilter
     appender.ERROR_LOGFILE.filter.threshold.level = WARN
 
-    appender.CARBON_SYS_LOG.type = Syslog
-    appender.CARBON_SYS_LOG.name = CARBON_SYS_LOG
-    appender.CARBON_SYS_LOG.host = localhost
-    appender.CARBON_SYS_LOG.facility = USER
-    appender.CARBON_SYS_LOG.layout.type = PatternLayout
-    appender.CARBON_SYS_LOG.layout.pattern = [%d] %5p - %x %m {%c}%n
-    appender.CARBON_SYS_LOG.filter.threshold.type = ThresholdFilter
-    appender.CARBON_SYS_LOG.filter.threshold.level = DEBUG
+    # appender.CARBON_SYS_LOG.type = Syslog
+    # appender.CARBON_SYS_LOG.name = CARBON_SYS_LOG
+    # appender.CARBON_SYS_LOG.host = localhost
+    # appender.CARBON_SYS_LOG.facility = USER
+    # appender.CARBON_SYS_LOG.layout.type = PatternLayout
+    # appender.CARBON_SYS_LOG.layout.pattern = [%d] %5p - %x %m {%c}%n
+    # appender.CARBON_SYS_LOG.filter.threshold.type = ThresholdFilter
+    # appender.CARBON_SYS_LOG.filter.threshold.level = DEBUG
 
     appender.OPEN_TRACING.type = RollingFile
     appender.OPEN_TRACING.name = OPEN_TRACING
@@ -231,10 +231,10 @@
     logger.org-apache-axis2-clustering.level = INFO
     logger.org-apache-axis2-clustering.additivity = false
 
-    logger.org-apache.name = org.apache
-    logger.org-apache.level = INFO
-    logger.org-apache.additivity = false
-    logger.org-apache.appenderRef.CARBON_LOGFILE.ref = CARBON_LOGFILE
+    # logger.org-apache.name = org.apache
+    # logger.org-apache.level = INFO
+    # logger.org-apache.additivity = false
+    # logger.org-apache.appenderRef.CARBON_LOGFILE.ref = CARBON_LOGFILE
 
     logger.org-apache-catalina.name = org.apache.catalina
     logger.org-apache-catalina.level = ERROR
@@ -295,8 +295,8 @@
     logger.me-prettyprint-cassandra-hector-TimingLogger.name = me.prettyprint.cassandra.hector.TimingLogger
     logger.me-prettyprint-cassandra-hector-TimingLogger.level = ERROR
 
-    logger.org-wso2.name = org.wso2
-    logger.org-wso2.level = INFO
+    # logger.org-wso2.name = org.wso2
+    # logger.org-wso2.level = INFO
 
     logger.org-wso2-carbon.name = org.wso2.carbon
     logger.org-wso2-carbon.level = INFO
@@ -417,11 +417,11 @@
     logger.hunsicker.name = de.hunsicker.jalopy.io
     logger.hunsicker.level = FATAL
 
-    logger.synapse-headers.name = org.apache.synapse.transport.http.headers
-    logger.synapse-headers.level = DEBUG
+    # logger.synapse-headers.name = org.apache.synapse.transport.http.headers
+    # logger.synapse-headers.level = DEBUG
 
-    logger.synapse-wire.name = org.apache.synapse.transport.http.wire
-    logger.synapse-wire.level = DEBUG
+    # logger.synapse-wire.name = org.apache.synapse.transport.http.wire
+    # logger.synapse-wire.level = DEBUG
 
     logger.thrift-publisher.name = org.wso2.carbon.databridge.agent.thrift.AsyncDataPublisher
     logger.thrift-publisher.level = WARN
@@ -467,5 +467,3 @@
     logger.org-wso2-carbon-apimgt-gateway-mediators-BotDetectionMediator.level = INFO
     logger.org-wso2-carbon-apimgt-gateway-mediators-BotDetectionMediator.appenderRef.BOTDATA_APPENDER.ref = BOTDATA_APPENDER
     logger.org-wso2-carbon-apimgt-gateway-mediators-BotDetectionMediator.additivity = false
-
-    category.SERVICE_APPENDER._OpenService_ = TRACE_APPENDER, BOTDATA_APPENDER


### PR DESCRIPTION
## Purpose

This PR updates the log4j2.properties in log4j.yaml file by,

- Commenting dangling logger and appender references. These are loggers and appenders that are defined but not registered in the initial loggers or appenders arrays.

- Removing category.SERVICE_APPENDER._OpenService_ = TRACE_APPENDER, BOTDATA_APPENDER a Log4j 1.x syntax (category.*) and is not supported at all by Log4j 2’s properties parser. Also from wso2apim-4.4.0 onwards this has not been used.

- Note that these changes are required due to the breaking changes introduced by log4j v2.25.x

## Related Issues

- https://github.com/wso2-enterprise/wso2-apim-internal/issues/14852
- https://github.com/wso2-enterprise/wso2-apim-internal/issues/15390