### PR TITLE
4.7.0 profile automation

### DIFF
--- a/kubernetes/cypress/Chart.yaml
+++ b/kubernetes/cypress/Chart.yaml
@@ -10,7 +10,7 @@
 # --------------------------------------------------------------------------------------
 
 apiVersion: v1
-appVersion: "4.5.0"
+appVersion: "4.7.0"
 description: A Helm chart to run cypress tests in a Kubernetes pod
 name: wso2am-cypress
-version: 4.5.0-1
+version: 4.7.0-1

--- a/kubernetes/gw-ingress/Chart.yaml
+++ b/kubernetes/gw-ingress/Chart.yaml
@@ -10,7 +10,7 @@
 # --------------------------------------------------------------------------------------
 
 apiVersion: v1
-appVersion: "4.5.0"
+appVersion: "4.7.0"
 description: A Helm chart for the deployment of WSO2 Gateway REST API
 name: wso2am-gw-rest
-version: 4.5.0-1
+version: 4.7.0-1

--- a/terraform/input.auto.tfvars
+++ b/terraform/input.auto.tfvars
@@ -18,33 +18,33 @@ default_tags = {
 }
 
 environment_name = "dev"
-vpc_cidr_block   = "172.18.0.0/16"
+vpc_cidr_block   = "172.19.0.0/16"
 
-management_subnet_az_cidr = "172.18.15.0/26"
+management_subnet_az_cidr = "172.19.15.0/26"
 
 eks_default_nodepool_desired_size         = "6"
 eks_default_nodepool_max_size             = "25"
 eks_default_nodepool_min_size             = "1"
 eks_default_nodepool_max_unavailable      = "1"
 eks_instance_types                        = ["c4.xlarge"]
-eks_availability_zone_1_subnet_cidr_block = "172.18.16.0/24"
-eks_availability_zone_2_subnet_cidr_block = "172.18.17.0/24"
-eks_external_lb_az1_subnet_cidr           = "172.18.19.0/24"
-eks_external_lb_az2_subnet_cidr           = "172.18.20.0/24"
+eks_availability_zone_1_subnet_cidr_block = "172.19.16.0/24"
+eks_availability_zone_2_subnet_cidr_block = "172.19.17.0/24"
+eks_external_lb_az1_subnet_cidr           = "172.19.19.0/24"
+eks_external_lb_az2_subnet_cidr           = "172.19.20.0/24"
 eks_service_ipv4_cidr                     = "10.0.0.0/16"
-az_dmz_subnet_cidr_block                  = "172.18.12.0/26"
+az_dmz_subnet_cidr_block                  = "172.19.12.0/26"
 kubernetes_version                        = "1.33"
 
 # DB
 db_engine_options = [
   {
     "engine"   : "mysql"
-    "version"  : "5.7"
+    "version"  : "8.0.43"
     "port"     : 3306
   },
   {
     "engine"   : "postgres"
-    "version"  : "14"
+    "version"  : "16.6"
     "port"     : 5432
   }
 ]
@@ -58,7 +58,7 @@ db_access_security_group_rules = [
     "from_port" : 0
     "to_port" : 3306
     "protocol" : "TCP"
-    "cidr_blocks" : ["172.18.10.0/24"]
+    "cidr_blocks" : ["172.19.10.0/24"]
     "security_groups" : []
   },
   {
@@ -78,8 +78,8 @@ db_access_security_group_rules = [
     "security_groups" : []
   }
 ]
-db_az1_subnet_cidr_block   = "172.18.12.128/26"
-db_az2_subnet_cidr_block   = "172.18.12.192/26"
+db_az1_subnet_cidr_block   = "172.19.12.128/26"
+db_az2_subnet_cidr_block   = "172.19.12.192/26"
 db_password                = "wso2carbon"
 db_backup_retention_period = 7
 


### PR DESCRIPTION
## Purpose
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues in the following format: Resolves issue1, issue2, etc.

Bump the Helm chart versions and Terraform infrastructure inputs to align this fork with the WSO2 APIM 4.7.0 release line. The existing chart versions still pointed at 4.5.0, and the VPC/subnet CIDRs and managed DB engine versions on the Terraform side were stale (overlapping CIDR ranges and out-of-support DB versions).

Resolves: N/A

## Goals
> Describe the solutions that this feature/fix will introduce to resolve the problems described above

- Align the `wso2am-cypress` and `wso2am-gw-rest` Helm charts with APIM 4.7.0.
- Move the EKS/DB VPC away from the `172.18.0.0/16` range to `172.19.0.0/16` to avoid CIDR collisions with peer environments.
- Bump the default managed DB engine versions (MySQL 5.7 → 8.0.43, Postgres 14 → 16.6) so the Terraform plan uses currently-supported RDS versions.

## Approach
> Describe how you are implementing the solutions. Include an animated GIF or screenshot if the change affects the UI (email documentation@wso2.com to review all UI text). Include a link to a Markdown file or Google doc if the feature write-up is too long to paste here.

- `kubernetes/cypress/Chart.yaml`: `appVersion` and `version` bumped from `4.5.0` / `4.5.0-1` to `4.7.0` / `4.7.0-1`.
- `kubernetes/gw-ingress/Chart.yaml`: same `appVersion` / `version` bump (`4.5.0` → `4.7.0`, `4.5.0-1` → `4.7.0-1`).
- `terraform/input.auto.tfvars`:
  - VPC CIDR block changed from `172.18.0.0/16` to `172.19.0.0/16`.
  - All dependent subnet CIDRs re-based onto `172.19.x.x` (management, EKS AZ1/AZ2, external LB AZ1/AZ2, DMZ, DB AZ1/AZ2).
  - DB access security-group rule CIDR for the MySQL port re-based to `172.19.10.0/24`.
  - `db_engine_options`: MySQL version `5.7` → `8.0.43`, Postgres version `14` → `16.6`.

No application code, JMeter plans, or integration test scripts are touched.

## User stories
> Summary of user stories addressed by this change

As a TestGrid operator, when I provision the APIM 4.7.0 test environment, the Helm charts and Terraform inputs deploy the correct 4.7.0 artifacts on a non-conflicting VPC with supported managed-DB versions.

## Release note
> Brief description of the new feature or bug fix as it will appear in the release notes

Bump Helm chart and Terraform inputs to APIM 4.7.0: chart `appVersion`/`version` aligned to 4.7.0, VPC re-based to `172.19.0.0/16`, and managed DB engine versions bumped to MySQL 8.0.43 and Postgres 16.6.

## Documentation
> Link(s) to product documentation that addresses the changes of this PR. If no doc impact, enter "N/A" plus brief explanation of why there's no doc impact

N/A — internal infrastructure/version-bump only; no user-facing product behaviour changes.

## Training
> Link to the PR for changes to the training content in https://github.com/wso2/WSO2-Training, if applicable

N/A

## Certification
> Type "Sent" when you have provided new/updated certification questions, plus four answers for each question (correct answer highlighted in bold), based on this change. Certification questions/answers should be sent to certification@wso2.com and NOT pasted in this PR. If there is no impact on certification exams, type "N/A" and explain why.

N/A — no impact on certification content; version/infra bump only.

## Marketing
> Link to drafts of marketing content that will describe and promote this feature, including product page changes, technical articles, blog posts, videos, etc., if applicable

N/A

## Automation tests
 - Unit tests
   > Code coverage information

   N/A — no application code changed.

 - Integration tests
   > Details about the test cases and coverage

   Existing TestGrid scenarios (03, 04, 05) will exercise the deployment end-to-end once the new chart and Terraform inputs are applied. Manual verification steps to run before merge:
   1. `helm lint kubernetes/cypress` and `helm lint kubernetes/gw-ingress` — confirm no template errors and the new versions render.
   2. `terraform -chdir=terraform fmt -check && terraform -chdir=terraform validate` — confirm the tfvars file is still syntactically valid.
   3. `terraform -chdir=terraform plan` against a dev account — confirm the plan re-creates VPC/subnet resources on `172.19.0.0/16` and shows the expected MySQL/Postgres version diffs without unexpected drift.
   4. Run an end-to-end TestGrid job on the 4.7.0 profile and confirm scenarios 03/04/05 pass against the freshly provisioned infra.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? N/A — no Java code changed
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes (note: `db_password = "wso2carbon"` already existed in the file and is unchanged; it is a non-secret default for the dev tfvars)

## Samples
> Provide high-level details about the samples related to this feature

N/A

## Related PRs
> List any other related PRs

- Follows on from `#332` (4.6.0 profile automation merge) and the prior 4.7.0 `Chart.yaml` bump commit `442a452`.

## Migrations (if applicable)
> Describe migration steps and platforms on which migration has been tested

The VPC CIDR change (`172.18.0.0/16` → `172.19.0.0/16`) and DB engine version bumps will force replacement of existing dev-environment networking and RDS resources on `terraform apply`. Before applying:
1. Tear down the existing dev environment (`./cleanup.sh` / `terraform destroy`) to avoid orphaned VPC/RDS resources.
2. Apply the new tfvars from a clean state.
3. Re-run TestGrid against the new environment.

No production migration is required — this tfvars file targets the `dev` environment only.

## Test environment
> List all JDK versions, operating systems, databases, and browser/versions on which this feature/fix was tested

- Kubernetes: EKS 1.33
- Managed DBs: MySQL 8.0.43, PostgreSQL 16.6
- Helm chart targets: WSO2 APIM 4.7.0

## Learning
> Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem.

Cross-referenced AWS RDS currently-supported engine versions for MySQL and PostgreSQL to pick the new defaults, and confirmed the new VPC CIDR does not overlap with neighbouring dev/test VPCs before re-basing the subnet ranges.
