### PR TITLE
Restore DS cypress report uploads to S3

### DIFF
--- a/kubernetes/cypress/templates/script-conf.yaml
+++ b/kubernetes/cypress/templates/script-conf.yaml
@@ -61,7 +61,9 @@ data:
     # Exfiltrate the report + failure screenshots to S3 before the pipeline
     # destroys this namespace. The inline mochawesome HTML embeds the failure
     # screenshots as base64, so the single report dir is self-contained; the
-    # raw cypress/screenshots dir is uploaded too for convenience. This
+    # raw screenshots are uploaded too — flattened into a single folder so
+    # downstream consumers (e.g. the Jenkins build page after the pipeline's
+    # post-test s3 cp) don't have to navigate spec-name subdirs. This
     # replaces the removed upload_email.js and restores parity with the
     # all-in-one pipeline (which ships test-outputs to S3 via post-actions).
     # Guarded with `|| true` so a delivery hiccup never masks the test verdict.
@@ -70,15 +72,37 @@ data:
     export AWS_ACCESS_KEY_ID="${S3_ACCESS_KEY}"
     export AWS_SECRET_ACCESS_KEY="${S3_SECRET_KEY}"
     export AWS_DEFAULT_REGION="${S3_REGION}"
+
+    # Prefer the deterministic prefix injected by the pipeline (lets Jenkins
+    # `aws s3 cp` the artifacts back into ${WORKSPACE}/logs/ and archive them on
+    # the build page). Fall back to a timestamp-suffixed legacy path so ad-hoc
+    # helm installs still get a unique destination.
+    {{- if .Values.s3_prefix }}
+    S3_DEST="s3://${S3_BUCKET}/{{ .Values.s3_prefix }}"
+    {{- else }}
     S3_DEST="s3://${S3_BUCKET}/ds-ui-tests/{{ .Values.host }}/${GIT_BRANCH}/$(date -u +%Y%m%d-%H%M%S)"
+    {{- end }}
+
     aws s3 cp cypress/reports/html "${S3_DEST}/report" --recursive || true
+
+    # Flatten cypress/screenshots/<spec>/<title>.png into a single
+    # cypress/screenshots-flat/<spec>__<title>.png file before upload.
+    # Cypress's default layout is folder-per-spec; the encoded prefix keeps
+    # filenames collision-safe across specs that share a test title.
     if [ -d cypress/screenshots ]; then
-        aws s3 cp cypress/screenshots "${S3_DEST}/screenshots" --recursive || true
+        mkdir -p cypress/screenshots-flat
+        find cypress/screenshots -type f -name '*.png' | while IFS= read -r f; do
+            rel="${f#cypress/screenshots/}"
+            flat="$(printf '%s' "$rel" | tr '/' '_' | tr ' ' '_')"
+            cp "$f" "cypress/screenshots-flat/${flat}"
+        done
+        aws s3 cp cypress/screenshots-flat "${S3_DEST}/screenshots" --recursive || true
     fi
+
     echo "===== DS test report (failure screenshots embedded in inline HTML) ====="
     echo "S3 location : ${S3_DEST}"
     echo "Report HTML : ${S3_DEST}/report/index.html"
-    echo "Screenshots : ${S3_DEST}/screenshots"
+    echo "Screenshots : ${S3_DEST}/screenshots  (flat layout)"
     echo "======================================================================="
 
     exit $MVNSTATE

--- a/kubernetes/cypress/templates/script-conf.yaml
+++ b/kubernetes/cypress/templates/script-conf.yaml
@@ -29,6 +29,10 @@ data:
     apt-get install -y g++ build-essential
     apt-get install -y curl
     apt-get install -y vim
+    # zip is required by 06-wsdl-url-generation.cy.js, which builds a .wsdl
+    # zip on the fly via cy.exec('zip ...'). The base cypress/included image
+    # does not ship it.
+    apt-get install -y zip
 
     # Add host mapping
     echo "{{ .Values.host_ip }} {{ .Values.host }}" >> /etc/hosts

--- a/kubernetes/cypress/templates/script-conf.yaml
+++ b/kubernetes/cypress/templates/script-conf.yaml
@@ -29,7 +29,7 @@ data:
     apt-get install -y g++ build-essential
     apt-get install -y curl
     apt-get install -y vim
-    # Required by 06-wsdl-url-generation.cy.js (cy.exec('zip ...')).
+    # Needed for tests that create zip archives via cy.exec.
     apt-get install -y zip
 
     # Add host mapping

--- a/kubernetes/cypress/templates/script-conf.yaml
+++ b/kubernetes/cypress/templates/script-conf.yaml
@@ -57,7 +57,28 @@ data:
     echo "Generating reports"
     npm run report:merge
     npm run report:generate
-    echo "Uploading reports to S3"
-    node ./upload_email.js
+
+    # Exfiltrate the report + failure screenshots to S3 before the pipeline
+    # destroys this namespace. The inline mochawesome HTML embeds the failure
+    # screenshots as base64, so the single report dir is self-contained; the
+    # raw cypress/screenshots dir is uploaded too for convenience. This
+    # replaces the removed upload_email.js and restores parity with the
+    # all-in-one pipeline (which ships test-outputs to S3 via post-actions).
+    # Guarded with `|| true` so a delivery hiccup never masks the test verdict.
+    echo "Uploading report and screenshots to S3"
+    apt-get install -y awscli || true
+    export AWS_ACCESS_KEY_ID="${S3_ACCESS_KEY}"
+    export AWS_SECRET_ACCESS_KEY="${S3_SECRET_KEY}"
+    export AWS_DEFAULT_REGION="${S3_REGION}"
+    S3_DEST="s3://${S3_BUCKET}/ds-ui-tests/{{ .Values.host }}/${GIT_BRANCH}/$(date -u +%Y%m%d-%H%M%S)"
+    aws s3 cp cypress/reports/html "${S3_DEST}/report" --recursive || true
+    if [ -d cypress/screenshots ]; then
+        aws s3 cp cypress/screenshots "${S3_DEST}/screenshots" --recursive || true
+    fi
+    echo "===== DS test report (failure screenshots embedded in inline HTML) ====="
+    echo "S3 location : ${S3_DEST}"
+    echo "Report HTML : ${S3_DEST}/report/index.html"
+    echo "Screenshots : ${S3_DEST}/screenshots"
+    echo "======================================================================="
 
     exit $MVNSTATE

--- a/kubernetes/cypress/templates/script-conf.yaml
+++ b/kubernetes/cypress/templates/script-conf.yaml
@@ -29,9 +29,7 @@ data:
     apt-get install -y g++ build-essential
     apt-get install -y curl
     apt-get install -y vim
-    # zip is required by 06-wsdl-url-generation.cy.js, which builds a .wsdl
-    # zip on the fly via cy.exec('zip ...'). The base cypress/included image
-    # does not ship it.
+    # Required by 06-wsdl-url-generation.cy.js (cy.exec('zip ...')).
     apt-get install -y zip
 
     # Add host mapping
@@ -62,25 +60,15 @@ data:
     npm run report:merge
     npm run report:generate
 
-    # Exfiltrate the report + failure screenshots to S3 before the pipeline
-    # destroys this namespace. The inline mochawesome HTML embeds the failure
-    # screenshots as base64, so the single report dir is self-contained; the
-    # raw screenshots are uploaded too — flattened into a single folder so
-    # downstream consumers (e.g. the Jenkins build page after the pipeline's
-    # post-test s3 cp) don't have to navigate spec-name subdirs. This
-    # replaces the removed upload_email.js and restores parity with the
-    # all-in-one pipeline (which ships test-outputs to S3 via post-actions).
-    # Guarded with `|| true` so a delivery hiccup never masks the test verdict.
+    # Upload report + screenshots to S3 before the namespace is torn down.
+    # Guarded with `|| true` so delivery hiccups don't mask the test verdict.
     echo "Uploading report and screenshots to S3"
     apt-get install -y awscli || true
     export AWS_ACCESS_KEY_ID="${S3_ACCESS_KEY}"
     export AWS_SECRET_ACCESS_KEY="${S3_SECRET_KEY}"
     export AWS_DEFAULT_REGION="${S3_REGION}"
 
-    # Prefer the deterministic prefix injected by the pipeline (lets Jenkins
-    # `aws s3 cp` the artifacts back into ${WORKSPACE}/logs/ and archive them on
-    # the build page). Fall back to a timestamp-suffixed legacy path so ad-hoc
-    # helm installs still get a unique destination.
+    # Prefer pipeline-injected prefix; fall back to timestamped path for ad-hoc helm installs.
     {{- if .Values.s3_prefix }}
     S3_DEST="s3://${S3_BUCKET}/{{ .Values.s3_prefix }}"
     {{- else }}
@@ -89,10 +77,7 @@ data:
 
     aws s3 cp cypress/reports/html "${S3_DEST}/report" --recursive || true
 
-    # Flatten cypress/screenshots/<spec>/<title>.png into a single
-    # cypress/screenshots-flat/<spec>__<title>.png file before upload.
-    # Cypress's default layout is folder-per-spec; the encoded prefix keeps
-    # filenames collision-safe across specs that share a test title.
+    # Flatten cypress/screenshots/<spec>/<title>.png → screenshots-flat/<spec>_<title>.png to avoid collisions.
     if [ -d cypress/screenshots ]; then
         mkdir -p cypress/screenshots-flat
         find cypress/screenshots -type f -name '*.png' | while IFS= read -r f; do

--- a/kubernetes/cypress/values.yaml
+++ b/kubernetes/cypress/values.yaml
@@ -27,3 +27,6 @@ aws_s3_bucket: "apim-ui-testing"
 aws_s3_access_key: ""
 aws_s3_secret_key: ""
 aws_s3_region: "us-east-1"
+# Deterministic S3 prefix injected by the pipeline (e.g. ds-ui-tests/${JOB_NAME}/build-${BUILD_NUMBER}/${pattern}-${db}).
+# When empty, the in-pod script falls back to the legacy timestamped path so ad-hoc helm installs still work.
+s3_prefix: ""

--- a/kubernetes/cypress/values.yaml
+++ b/kubernetes/cypress/values.yaml
@@ -27,6 +27,5 @@ aws_s3_bucket: "apim-ui-testing"
 aws_s3_access_key: ""
 aws_s3_secret_key: ""
 aws_s3_region: "us-east-1"
-# Deterministic S3 prefix injected by the pipeline (e.g. ds-ui-tests/${JOB_NAME}/build-${BUILD_NUMBER}/${pattern}-${db}).
-# When empty, the in-pod script falls back to the legacy timestamped path so ad-hoc helm installs still work.
+# Optional S3 prefix from the pipeline; empty falls back to a timestamped path.
 s3_prefix: ""


### PR DESCRIPTION
## Purpose
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues in the following format: Resolves issue1, issue2, etc.

Fix the DS (downstream) cypress test pipeline's report exfiltration so failure screenshots and the mochawesome HTML survive namespace teardown and reach the Jenkins build page.

The DS cypress Job's only report-upload step (`node ./upload_email.js`) crashed with `MODULE_NOT_FOUND` because that script was removed from the test repo — so every DS run lost its report and screenshots. Separately, `06-wsdl-url-generation.cy.js` fails on every DS run because it builds a `.wsdl` zip on the fly via `cy.exec('zip ...')` and the base `cypress/included` image doesn't ship the `zip` binary.

Resolves: N/A

## Goals
> Describe the solutions that this feature/fix will introduce to resolve the problems described above

- Restore DS cypress report + failure-screenshot visibility on par with the all-in-one pipeline by uploading them to S3 before namespace teardown.
- Let the DS Jenkins pipeline target a deterministic S3 prefix so it can `aws s3 cp` the artifacts back into the workspace and `archiveArtifacts` them on the build page.
- Install the missing `zip` binary in the in-pod cypress runner so `06-wsdl-url-generation.cy.js` stops failing on `cy.exec('zip ...')`.

## Approach
> Describe how you are implementing the solutions. Include an animated GIF or screenshot if the change affects the UI (email documentation@wso2.com to review all UI text). Include a link to a Markdown file or Google doc if the feature write-up is too long to paste here.

**DS cypress report exfiltration (`kubernetes/cypress/templates/script-conf.yaml`, `values.yaml`)**
- Replace the dead `node ./upload_email.js` call with an `aws s3 cp` of `cypress/reports/html` and `cypress/screenshots` using the S3 credentials already injected into the Job. Guarded with `|| true` so a delivery failure never masks the real test verdict.
- Add `s3_prefix` to `values.yaml` (default empty). When set, the in-pod script uploads to `s3://${bucket}/${prefix}`; when unset, it falls back to the legacy timestamp-suffixed `ds-ui-tests/<host>/<branch>/<ts>` path so ad-hoc helm installs still produce a unique destination.
- Flatten `cypress/screenshots/<spec>/<title>.png` into `cypress/screenshots-flat/<spec>__<title>.png` before upload so reviewers (and the Jenkins archive) don't have to navigate per-spec subdirs. The encoded prefix keeps filenames collision-safe across specs sharing a title.

**Cypress runner image (`kubernetes/cypress/templates/script-conf.yaml`)**
- Install `zip` alongside the existing `g++`/`curl`/`vim` apt-gets in the in-pod script so `06-wsdl-url-generation.cy.js` stops failing on `cy.exec('zip ...')`.

No application code, JMeter plans, integration test scripts, Helm chart versions, or Terraform inputs are touched.

## User stories
> Summary of user stories addressed by this change

- As a developer triaging a failed DS cypress run, I can open the Jenkins build page and see the mochawesome HTML report plus the failure screenshots without having to re-run the suite locally.
- As the DS Jenkins pipeline, I can pass a deterministic S3 prefix via `helm --set s3_prefix=...` and reliably `aws s3 cp` the artifacts back into `${WORKSPACE}/logs/` for `archiveArtifacts`.
- As a DS cypress run, `06-wsdl-url-generation.cy.js` no longer fails on `cy.exec('zip ...')` because the in-pod image now has `zip` installed.

## Release note
> Brief description of the new feature or bug fix as it will appear in the release notes

Restore DS cypress report and failure-screenshot uploads to S3 (replacing the removed `upload_email.js` step) with an optional deterministic `s3_prefix` for pipeline-driven destinations, flatten screenshots before upload, and install `zip` in the in-pod runner so the WSDL spec stops failing on `cy.exec`.

## Documentation
> Link(s) to product documentation that addresses the changes of this PR. If no doc impact, enter "N/A" plus brief explanation of why there's no doc impact

N/A — internal test-pipeline change; no user-facing product behaviour changes.

## Training
> Link to the PR for changes to the training content in https://github.com/wso2/WSO2-Training, if applicable

N/A

## Certification
> Type "Sent" when you have provided new/updated certification questions, plus four answers for each question (correct answer highlighted in bold), based on this change. Certification questions/answers should be sent to certification@wso2.com and NOT pasted in this PR. If there is no impact on certification exams, type "N/A" and explain why.

N/A — no impact on certification content; internal test-pipeline change only.

## Marketing
> Link to drafts of marketing content that will describe and promote this feature, including product page changes, technical articles, blog posts, videos, etc., if applicable

N/A

## Automation tests
 - Unit tests
   > Code coverage information

   N/A — no application code changed.

 - Integration tests
   > Details about the test cases and coverage

   The existing DS cypress suite exercises this code path on every run. Manual verification steps to run before merge:
   1. `helm lint kubernetes/cypress` — confirm no template errors.
   2. `helm template kubernetes/cypress --set s3_prefix=ds-ui-tests/foo/bar` and confirm the rendered in-pod script uses `s3://${S3_BUCKET}/ds-ui-tests/foo/bar` as `S3_DEST`; with `s3_prefix` unset, confirm it falls back to the timestamp-suffixed legacy path.
   3. Run a DS pipeline job end-to-end and confirm: (a) the cypress pod's apt-get installs `zip`, (b) `06-wsdl-url-generation.cy.js` no longer fails on `cy.exec`, (c) `cypress/reports/html/` and the flattened `cypress/screenshots-flat/` land at `s3://${bucket}/${s3_prefix}/`, and (d) the Jenkins build page shows the archived report + screenshots.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? N/A — no Java code changed
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes — S3 credentials are consumed from existing Job-level `${S3_ACCESS_KEY}` / `${S3_SECRET_KEY}` env vars and not committed.

## Samples
> Provide high-level details about the samples related to this feature

N/A

## Related PRs
> List any other related PRs

- Builds on top of `#340` (4.7.0 profile automation).
- Paired pipeline-side change: `testgrid-jenkins-library/integration-ui.groovy` consumes the new `s3_prefix` value and runs the post-test `aws s3 cp` back into the Jenkins workspace.

## Migrations (if applicable)
> Describe migration steps and platforms on which migration has been tested

No migration required. The cypress chart changes are backwards-compatible: `s3_prefix` defaults to empty (legacy timestamp path), and existing callers that don't set it continue to work.

## Test environment
> List all JDK versions, operating systems, databases, and browser/versions on which this feature/fix was tested

- Cypress runner: `cypress/included` base image with `zip`, `g++`, `curl`, `vim`, `awscli` apt-installed in-pod
- S3 region: `us-east-1` (`apim-ui-testing` bucket)
- Kubernetes: EKS 1.33

## Learning
> Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem.

Traced the existing all-in-one pipeline's post-action S3 upload to mirror its layout (`report/`, `screenshots/`) so downstream consumers see a consistent structure across pipelines. Chose a flat screenshot layout because mochawesome already embeds failure screenshots as base64 in the inline HTML — the raw files are kept only as a fallback for reviewers who want the originals.
