### PR TITLE
Add test_specs support to cypress chart for selective spec runs

### DIFF
--- a/kubernetes/cypress/templates/cypress-job.yaml
+++ b/kubernetes/cypress/templates/cypress-job.yaml
@@ -68,6 +68,8 @@ spec:
               secretKeyRef:
                 name: test-secret
                 key: aws-s3-secret-key
+          - name: TEST_SPECS
+            value: {{ .Values.test_specs | quote }}
         volumeMounts:
         - name: test-script
           mountPath: /cypress/script.sh

--- a/kubernetes/cypress/templates/script-conf.yaml
+++ b/kubernetes/cypress/templates/script-conf.yaml
@@ -53,7 +53,15 @@ data:
     nohup Xvfb :99 > /dev/null 2>&1 &
     export DISPLAY=:99
     echo "Running tests"
-    NO_COLOR=1 npm run test -- --env gatewayUrl=https://{{ .Values.gw_hostname }}
+    if [ -n "$TEST_SPECS" ]; then
+        echo "===== test_specs set — running user-selected specs only ====="
+        echo "$TEST_SPECS" | tr ',' '\n'
+        NO_COLOR=1 npx cypress run --e2e \
+            --spec "$TEST_SPECS" \
+            --env gatewayUrl=https://{{ .Values.gw_hostname }}
+    else
+        NO_COLOR=1 npm run test -- --env gatewayUrl=https://{{ .Values.gw_hostname }}
+    fi
     MVNSTATE=$?
     pkill Xvfb
     echo "Generating reports"

--- a/kubernetes/cypress/values.yaml
+++ b/kubernetes/cypress/values.yaml
@@ -29,3 +29,7 @@ aws_s3_secret_key: ""
 aws_s3_region: "us-east-1"
 # Optional S3 prefix from the pipeline; empty falls back to a timestamped path.
 s3_prefix: ""
+
+# Optional comma-separated Cypress spec paths/globs (relative to tests/).
+# Empty = run the full suite. Set by the Jenkins pipeline via --set.
+test_specs: ""


### PR DESCRIPTION
## Purpose
Allow the DS pipeline to scope a Cypress run to a subset of specs, mirroring the all-in-one pipeline's `test_specs` parameter.

## Goals
Thread an optional comma-separated list of spec paths into the test-runner Job; empty value preserves full-suite behavior.

## Approach
- Add `test_specs` to `values.yaml` (default empty).
- Inject it as `TEST_SPECS` env in `cypress-job.yaml`.
- Branch in `script-conf.yaml`: when set, invoke `npx cypress run --spec "$TEST_SPECS"`; otherwise fall back to `npm run test`.

## User stories
N/A.

## Release note
N/A — DS test infrastructure only.

## Documentation
N/A — internal test infra change.

## Training
N/A.

## Certification
N/A.

## Marketing
N/A.

## Automation tests
- Unit tests
  N/A.
- Integration tests
  Validated via Jenkins DS pipeline runs that pass and omit `test_specs`.

## Security checks
- Followed secure coding standards: yes
- Ran FindSecurityBugs plugin and verified report: N/A (Helm chart change)
- Confirmed no secrets in PR: yes

## Samples
N/A.

## Related PRs
- Builds on #341 (Restore DS cypress report uploads to S3).
- Consumer-side change: testgrid-jenkins-library pipeline passes `test_specs` via `--set`.

## Migrations (if applicable)
N/A.

## Test environment
JDK 21, Rocky 9, MySQL 5.7, Cypress 14.5.4.

## Learning
N/A.