### PR TITLE
Gateway API: profile-test SNI connection + kubernetes/gateway-api manifests

### DIFF
--- a/kubernetes/gateway-api/gateway.yaml
+++ b/kubernetes/gateway-api/gateway.yaml
@@ -1,3 +1,14 @@
+# -------------------------------------------------------------------------------------
+#
+# Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com). All Rights Reserved.
+#
+# This software is the property of WSO2 LLC. and its suppliers, if any.
+# Dissemination of any information or reproduction of any material contained
+# herein is strictly forbidden, unless permitted by WSO2 in accordance with the
+# WSO2 Commercial License available at https://wso2.com/licenses/eula/3.2
+#
+# --------------------------------------------------------------------------------------
+
 # Gateway the helm-apim HTTPRoutes attach to. Listener sectionNames
 # (control-plane/gateway/websocket/websub-https) and hostnames must match the chart;
 # allowedRoutes=Same (the Gateway lives in the same namespace as the routes).

--- a/kubernetes/gateway-api/gateway.yaml
+++ b/kubernetes/gateway-api/gateway.yaml
@@ -1,0 +1,60 @@
+# Gateway the helm-apim HTTPRoutes attach to. Listener sectionNames
+# (control-plane/gateway/websocket/websub-https) and hostnames must match the chart;
+# allowedRoutes=Same (the Gateway lives in the same namespace as the routes).
+# Rendered by the pipeline: substitute the __PLACEHOLDER__ tokens before kubectl apply.
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: wso2-apim-gateway
+  namespace: __NAMESPACE__
+spec:
+  gatewayClassName: eg
+  listeners:
+  - name: control-plane-https
+    hostname: "__CONTROL_PLANE_HOST__"
+    port: 443
+    protocol: HTTPS
+    tls:
+      mode: Terminate
+      certificateRefs:
+      - kind: Secret
+        name: wso2-apim-tls
+    allowedRoutes:
+      namespaces:
+        from: Same
+  - name: gateway-https
+    hostname: "__GATEWAY_HOST__"
+    port: 443
+    protocol: HTTPS
+    tls:
+      mode: Terminate
+      certificateRefs:
+      - kind: Secret
+        name: wso2-apim-tls
+    allowedRoutes:
+      namespaces:
+        from: Same
+  - name: websocket-https
+    hostname: "__WEBSOCKET_HOST__"
+    port: 443
+    protocol: HTTPS
+    tls:
+      mode: Terminate
+      certificateRefs:
+      - kind: Secret
+        name: wso2-apim-tls
+    allowedRoutes:
+      namespaces:
+        from: Same
+  - name: websub-https
+    hostname: "__WEBSUB_HOST__"
+    port: 443
+    protocol: HTTPS
+    tls:
+      mode: Terminate
+      certificateRefs:
+      - kind: Secret
+        name: wso2-apim-tls
+    allowedRoutes:
+      namespaces:
+        from: Same

--- a/kubernetes/gateway-api/gatewayclass-eg.yaml
+++ b/kubernetes/gateway-api/gatewayclass-eg.yaml
@@ -1,0 +1,6 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: GatewayClass
+metadata:
+  name: eg
+spec:
+  controllerName: gateway.envoyproxy.io/gatewayclass-controller

--- a/kubernetes/gateway-api/gatewayclass-eg.yaml
+++ b/kubernetes/gateway-api/gatewayclass-eg.yaml
@@ -1,3 +1,14 @@
+# -------------------------------------------------------------------------------------
+#
+# Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com). All Rights Reserved.
+#
+# This software is the property of WSO2 LLC. and its suppliers, if any.
+# Dissemination of any information or reproduction of any material contained
+# herein is strictly forbidden, unless permitted by WSO2 in accordance with the
+# WSO2 Commercial License available at https://wso2.com/licenses/eula/3.2
+#
+# --------------------------------------------------------------------------------------
+
 apiVersion: gateway.networking.k8s.io/v1
 kind: GatewayClass
 metadata:

--- a/kubernetes/gateway-api/gw-rest-httproute.yaml
+++ b/kubernetes/gateway-api/gw-rest-httproute.yaml
@@ -1,3 +1,14 @@
+# -------------------------------------------------------------------------------------
+#
+# Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com). All Rights Reserved.
+#
+# This software is the property of WSO2 LLC. and its suppliers, if any.
+# Dissemination of any information or reproduction of any material contained
+# herein is strictly forbidden, unless permitted by WSO2 in accordance with the
+# WSO2 Commercial License available at https://wso2.com/licenses/eula/3.2
+#
+# --------------------------------------------------------------------------------------
+
 # The chart's gateway HTTPRoute sends gw- -> 8243 (API traffic), but the gateway mgmt REST
 # API (/api/am/gateway/v2/) is on 9443 (nginx used gw-ingress). This HTTPRoute routes that
 # path to 9443. Rendered by the pipeline: substitute the __PLACEHOLDER__ tokens before apply.

--- a/kubernetes/gateway-api/gw-rest-httproute.yaml
+++ b/kubernetes/gateway-api/gw-rest-httproute.yaml
@@ -1,0 +1,22 @@
+# The chart's gateway HTTPRoute sends gw- -> 8243 (API traffic), but the gateway mgmt REST
+# API (/api/am/gateway/v2/) is on 9443 (nginx used gw-ingress). This HTTPRoute routes that
+# path to 9443. Rendered by the pipeline: substitute the __PLACEHOLDER__ tokens before apply.
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: gw-rest-httproute
+  namespace: __NAMESPACE__
+spec:
+  parentRefs:
+  - name: wso2-apim-gateway
+    sectionName: gateway-https
+  hostnames:
+  - "__GATEWAY_HOST__"
+  rules:
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /api/am/gateway/v2/
+    backendRefs:
+    - name: apim-universal-gw-wso2am-universal-gw-service
+      port: 9443

--- a/kubernetes/gateway-api/gw-teardown.sh
+++ b/kubernetes/gateway-api/gw-teardown.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# Release the Gateway API load balancers (AWS ELBs) that Terraform does not manage.
+# Delete the Gateways + EnvoyProxy LB Services directly so the cloud controller removes the
+# ELBs; do NOT uninstall the Envoy Gateway controller first, or the orphaned ELB's ENIs stall
+# terraform destroy ~20 min. Then wait until every cluster-owned ELB is actually gone.
+# Usage: gw-teardown.sh <kube-context> <region> <cluster-name>
+set +e
+KCTX="$1"; REGION="$2"; CLUSTER="$3"
+echo "Releasing Gateway API load balancers for cluster $CLUSTER"
+kubectl --context="$KCTX" delete gateway --all --all-namespaces --ignore-not-found --timeout=180s || echo "No Gateways to delete."
+kubectl --context="$KCTX" delete svc -n envoy-gateway-system -l gateway.envoyproxy.io/owning-gateway-namespace --ignore-not-found || true
+gone=0
+for i in $(seq 1 40); do
+  out=$(aws elb describe-load-balancers --region "$REGION" --query "LoadBalancerDescriptions[].LoadBalancerName" --output text 2>/dev/null)
+  rc=$?
+  LEFT=""
+  if [ $rc -eq 0 ]; then
+    for lb in $out; do
+      aws elb describe-tags --region "$REGION" --load-balancer-names "$lb" --query "TagDescriptions[].Tags[?Key=='kubernetes.io/cluster/$CLUSTER'].Value" --output text 2>/dev/null | grep -q owned && LEFT="$LEFT $lb"
+    done
+    if [ -z "$LEFT" ]; then gone=$((gone+1)); [ $gone -ge 2 ] && { echo "Cluster ELBs released."; break; }; else gone=0; fi
+  else
+    gone=0
+  fi
+  echo "Waiting for cluster ELBs to delete:${LEFT:- (rechecking)}"; sleep 15
+done

--- a/kubernetes/gateway-api/gw-teardown.sh
+++ b/kubernetes/gateway-api/gw-teardown.sh
@@ -1,4 +1,15 @@
 #!/usr/bin/env bash
+
+# -------------------------------------------------------------------------------------
+#
+# Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com). All Rights Reserved.
+#
+# This software is the property of WSO2 LLC. and its suppliers, if any.
+# Dissemination of any information or reproduction of any material contained
+# herein is strictly forbidden, unless permitted by WSO2 in accordance with the
+# WSO2 Commercial License available at https://wso2.com/licenses/eula/3.2
+#
+# --------------------------------------------------------------------------------------
 # Release the Gateway API load balancers (AWS ELBs) that Terraform does not manage.
 # Delete the Gateways + EnvoyProxy LB Services directly so the cloud controller removes the
 # ELBs; do NOT uninstall the Envoy Gateway controller first, or the orphaned ELB's ENIs stall

--- a/main.sh
+++ b/main.sh
@@ -24,11 +24,30 @@ do
             kubernetes_namespace="${arg#*=}"
             shift
             ;;
+        --LB_IP=*)
+            LB_IP="${arg#*=}"
+            shift
+            ;;
+        --USE_GATEWAY_API=*)
+            USE_GATEWAY_API="${arg#*=}"
+            shift
+            ;;
         *)
             # unknown option
             ;;
     esac
 done
+
+# Gateway API (4.7.0+) routes HTTPS by TLS SNI: map the APIM hostnames to the Envoy LB IP.
+if [ "${USE_GATEWAY_API}" = "true" ] && [ -n "${LB_IP}" ]; then
+    echo "Gateway API mode: mapping ${PORTAL_HOST} and ${GATEWAY_HOST} -> ${LB_IP} in /etc/hosts"
+    # Reused agents keep stale entries that shadow the fresh mapping -> ETIMEDOUT; clear first.
+    for h in "${PORTAL_HOST}" "${GATEWAY_HOST}"; do
+        sudo sed -i "\|${h}|d" /etc/hosts > /dev/null 2>&1 || sed -i "\|${h}|d" /etc/hosts > /dev/null 2>&1 || true
+    done
+    HOSTS_LINE="${LB_IP} ${PORTAL_HOST} ${GATEWAY_HOST}"
+    echo "${HOSTS_LINE}" | sudo tee -a /etc/hosts > /dev/null 2>&1 || echo "${HOSTS_LINE}" >> /etc/hosts
+fi
 
 kubectl get pods -l product=apim -n="${kubernetes_namespace}"  -o custom-columns=:metadata.name > podNames.txt
 dateWithMinute=$(date +"%Y_%m_%d_%H_%M")
@@ -105,6 +124,7 @@ operation_policy_file_path="$tests_dir/tests-cases/profile-tests/resources/opera
 /home/ubuntu/.nvm/versions/node/v19.0.1/bin/newman run "$collection_file" \
     --environment "$environment_file" \
     --env-var "cluster_ip=${HOST_NAME}" \
+    --env-var "useGatewayApi=${USE_GATEWAY_API}" \
     --env-var "pizzashack_endpoint=https://apim-acp-wso2am-acp-service:9443/am/sample/pizzashack/v1/api/" \
     --env-var "operation_policy_file_path=$operation_policy_file_path" \
     --env-var "portals_host=${PORTAL_HOST}" \

--- a/tests-cases/profile-tests/Profile_Setup_Tests.postman_collection.json
+++ b/tests-cases/profile-tests/Profile_Setup_Tests.postman_collection.json
@@ -5,6 +5,26 @@
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
 		"_exporter_id": "3432412"
 	},
+	"event": [
+		{
+			"listen": "prerequest",
+			"script": {
+				"type": "text/javascript",
+				"exec": [
+					"// Gateway API (4.7.0+) SNI routing: rewrite each request's URL host to its resolved Host.",
+					"if (pm.environment.get('useGatewayApi') === 'true' || pm.variables.get('useGatewayApi') === 'true') {",
+					"    var hostHeader = pm.request.headers.get('Host');",
+					"    if (hostHeader) {",
+					"        var resolved = pm.variables.replaceIn(hostHeader);",
+					"        if (resolved && resolved.indexOf('{{') === -1) {",
+					"            pm.request.url.host = resolved.split('.');",
+					"        }",
+					"    }",
+					"}"
+				]
+			}
+		}
+	],
 	"item": [
 		{
 			"name": "Authentication for the Super Admin",


### PR DESCRIPTION
## Purpose

APIM 4.7.0+ deploys behind the Kubernetes Gateway API (Envoy Gateway) instead of nginx Ingress. This PR carries the `apim-test-integration` side of that migration: the connection-side changes the profile test needs on Gateway API, plus the Gateway API Kubernetes manifests/teardown script (moved out of the pipeline into this repo per review on wso2/testgrid-jenkins-library#297).

## Changes

**1. Connect profile tests by real hostname (SNI)** — `31adc37`
Envoy selects the HTTPS listener by **TLS SNI** and requires SNI == Host, so the profile test's old approach of hitting the ELB with a `Host:` header fails (nginx did L7 Host routing).
- `main.sh` maps the APIM hostnames to the Envoy LB IP in `/etc/hosts` (gated on `--USE_GATEWAY_API`/`--LB_IP`) so newman presents the correct SNI, and clears any stale entry first (reused agents; glibc returns the first match, so a torn-down LB IP would shadow the fresh mapping → `connect ETIMEDOUT`).
- Collection pre-request script (gated on `useGatewayApi`) rewrites each request's URL host to its resolved `Host` header so SNI matches the listener.

**2. Gateway API manifests + teardown script under `kubernetes/gateway-api/`** — `1cc8709`
Externalized from the TestGrid pipeline heredocs so the k8s YAML lives in this repo (existing convention: `kubernetes/gw-ingress/`, `kubernetes/cypress/`):
- `gatewayclass-eg.yaml` — Envoy `GatewayClass` (static).
- `gateway.yaml` — per-namespace `Gateway` with the 4 HTTPS listeners; `__PLACEHOLDER__` tokens for namespace + listener hostnames, rendered by the pipeline.
- `gw-rest-httproute.yaml` — routes `/api/am/gateway/v2/` to the gateway on 9443 (the chart's HTTPRoute sends gw- → 8243); tokens for namespace + gateway host.
- `gw-teardown.sh` — releases the Envoy-provisioned ELBs before `terraform destroy` (deletes Gateways + LB Services, waits for cluster-tagged ELBs to clear; orphaned ENIs otherwise stall VPC teardown ~20 min). Args: `<kube-context> <region> <cluster>`.

## Files

- `main.sh`, `tests-cases/profile-tests/Profile_Setup_Tests.postman_collection.json` (modified)
- `kubernetes/gateway-api/{gatewayclass-eg.yaml, gateway.yaml, gw-rest-httproute.yaml, gw-teardown.sh}` (added)

Gated on Gateway-API mode only; the nginx/Ingress path (4.5.0/4.6.0) is unaffected.

## Validation

Validated end-to-end via the `Kubernetes-deployments/APIM/APIM470` profile pipeline (build **#62**, pipeline pointed at this branch): Envoy Gateway installs cleanly, the externalized manifests are rendered (token-substituted) and applied, all 4 peer-test patterns (acp/tm/gw/all) pass — **195 assertions, 0 failures, 0 ETIMEDOUT** each — and `gw-teardown.sh` releases the ELBs before a clean destroy.

Branch is 2 ahead / 0 behind the base, so this merges as a clean fast-forward.