### PR TITLE
[3.2.0] Add Cypress test for Resident IdP page crash on restricted permissions

### DIFF
--- a/cypress/integration/04-carbon/00-resident-idp-permission-check.spec.js
+++ b/cypress/integration/04-carbon/00-resident-idp-permission-check.spec.js
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Provisions a role/user with /permission/admin/manage/identity/idpmgt/view but NOT the broader
+// /permission/admin/manage, logs in as that user, opens the Resident IdP edit page, and asserts it
+// renders normally with no server error.
+describe("admin-12 : Resident IdP edit page access without admin/manage permission", () => {
+    const role = 'idpViewOnlyRole';
+    const username = 'idpViewOnlyUser';
+    const password = 'Console@123';
+    const permissions = [
+        '/permission/admin/login',
+        '/permission/admin/manage/identity/idpmgt/view',
+    ];
+
+    before(function () {
+        cy.soapLoginAsAdmin();
+
+        // Start clean in case a previous run left the fixtures behind.
+        cy.soapDeleteUser(username);
+        cy.soapDeleteRole(role);
+
+        cy.soapCreateRole(role, permissions);
+        cy.soapCreateUser(username, password, [role]);
+
+        cy.clearCookies();
+        cy.carbonLogin(username, password);
+    });
+
+    after(function () {
+        cy.soapLoginAsAdmin();
+        cy.soapDeleteUser(username);
+        cy.soapDeleteRole(role);
+    });
+
+    it.only("carbon-00 : User with idpmgt/view permission (but not admin/manage) can open the Resident IdP edit page", () => {
+        // idp-mgt-edit-load-local.jsp fetches the Resident IdP into the session then client-side redirects
+        // to idp-mgt-edit-local.jsp - a real browser follows that redirect, so visiting the loader once
+        // lands us on the actual edit page.
+        cy.visit('/carbon/idpmgt/idp-mgt-edit-load-local.jsp');
+        cy.url().should('include', 'idp-mgt-edit-local.jsp');
+
+        cy.contains('Resident Identity Provider').should('exist');
+        cy.get('body').should('not.contain', 'AxisFault');
+        cy.get('body').should('not.contain', 'JSPException while including page');
+    });
+});

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -2,6 +2,11 @@ import 'cypress-file-upload';
 import Portals from "../support/functions/Portals";
 
 //const commandDelay = 0;
+const CARBON_SOAP = {
+    auth: 'http://authentication.services.core.carbon.wso2.org',
+    userStore: 'http://service.ws.um.carbon.wso2.org',
+    userMgt: 'http://common.mgt.user.carbon.wso2.org/xsd',
+};
 
 Cypress.Commands.add('carbonLogin', (username, password) => {
     Cypress.log({
@@ -354,3 +359,57 @@ Cypress.Commands.add('logoutFromPublisher', () => {
 //        });
 //    });
 //}
+
+// Fire a SOAP call against a carbon admin service. Cookies from a prior call
+// (e.g. the admin login session) are reused automatically by cy.request.
+Cypress.Commands.add('carbonSoap', (service, namespace, operation, innerXml, extraXmlns = '') => {
+    const body =
+        `<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ser="${namespace}"${extraXmlns}>` +
+        `<soapenv:Header/><soapenv:Body><ser:${operation}>${innerXml}</ser:${operation}></soapenv:Body></soapenv:Envelope>`;
+    return cy.request({
+        method: 'POST',
+        url: `/services/${service}`,
+        headers: { 'Content-Type': 'text/xml; charset=UTF-8', 'SOAPAction': `urn:${operation}` },
+        body,
+        failOnStatusCode: false,
+    });
+});
+
+Cypress.Commands.add('soapLoginAsAdmin', (username = 'admin', password = 'admin') => {
+    cy.carbonSoap('AuthenticationAdmin', CARBON_SOAP.auth, 'login',
+        `<ser:username>${username}</ser:username>` +
+        `<ser:password>${password}</ser:password>` +
+        `<ser:remoteAddress>127.0.0.1</ser:remoteAddress>`)
+        .its('body').should('contain', '<ns:return>true</ns:return>');
+});
+
+// Create a role and grant it the given permissions (each with the ui.execute action).
+Cypress.Commands.add('soapCreateRole', (roleName, permissions = []) => {
+    const permissionsXml = permissions.map(p =>
+        `<ser:permissions><xsd:resourceId>${p}</xsd:resourceId><xsd:action>ui.execute</xsd:action></ser:permissions>`).join('');
+    cy.carbonSoap('RemoteUserStoreManagerService', CARBON_SOAP.userStore, 'addRole',
+        `<ser:roleName>${roleName}</ser:roleName>${permissionsXml}`,
+        ` xmlns:xsd="${CARBON_SOAP.userMgt}"`)
+        .its('status').should('eq', 202);
+});
+
+// Create a user with the given password and assign them to the given roles.
+Cypress.Commands.add('soapCreateUser', (username, password, roles = []) => {
+    const rolesXml = roles.map(r => `<ser:roleList>${r}</ser:roleList>`).join('');
+    cy.carbonSoap('RemoteUserStoreManagerService', CARBON_SOAP.userStore, 'addUser',
+        `<ser:userName>${username}</ser:userName>` +
+        `<ser:credential>${password}</ser:credential>${rolesXml}` +
+        `<ser:requirePasswordChange>false</ser:requirePasswordChange>`)
+        .its('status').should('eq', 202);
+});
+
+Cypress.Commands.add('soapDeleteRole', (roleName) => {
+    cy.carbonSoap('RemoteUserStoreManagerService', CARBON_SOAP.userStore, 'deleteRole',
+        `<ser:roleName>${roleName}</ser:roleName>`);
+});
+
+// Best-effort: a 500 (user does not exist) is fine, so status is not asserted.
+Cypress.Commands.add('soapDeleteUser', (username) => {
+    cy.carbonSoap('RemoteUserStoreManagerService', CARBON_SOAP.userStore, 'deleteUser',
+        `<ser:userName>${username}</ser:userName>`);
+});


### PR DESCRIPTION
## Summary
- Adds a Cypress spec covering the fix for a user with `idpmgt/view` but not `admin/manage` permission crashing the Resident IdP edit page instead of it rendering with the `AxisFault` from `IdentityGovernanceAdminService#getConnectorList` handled gracefully.
- Adds a small `carbonSoap`-based provisioning layer (`soapLoginAsAdmin`, `soapCreateRole`, `soapCreateUser`, `soapDeleteRole`, `soapDeleteUser`) in `commands.js` so the spec provisions and tears down its own role/user rather than depending on one already existing on the pack.

## Test plan
- [x] Ran against a pack without the fix - confirmed the spec fails (page crashes, `AxisFault`/`JSPException` present in the response body).
- [x] Ran against a pack with the fix applied - confirmed the spec passes.