### PR TITLE
[APIM440] Use a dedicated pull secret for registry.wso2.com

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -110,6 +110,18 @@ fi
 # Create fargate profile
 eksctl create fargateprofile --cluster "${EKS_CLUSTER_NAME}" --name "${product_name}-${SHORT_PRODUCT_VERSION}-fargate-profile" --namespace "${kubernetes_namespace}" --region ${EKS_CLUSTER_REGION} || { echo "Failed to create fargate profile." ; exit 1 ; }
 
+# Create the namespace up front so the registry pull secret can be placed in it.
+kubectl create namespace "${kubernetes_namespace}" --dry-run=client -o yaml | kubectl apply -f - || { echo 'Failed to create namespace.'; exit 1; }
+
+# Pull secret for the private container registry. Kept separate from the WSO2 Updates
+# credentials (wso2.subscription.*), which authenticate against a different service.
+kubectl create secret docker-registry wso2-registry-creds \
+    --docker-server=registry.wso2.com \
+    --docker-username="${REGISTRY_CREDS_USR}" \
+    --docker-password="${REGISTRY_CREDS_PSW}" \
+    --namespace "${kubernetes_namespace}" \
+    --dry-run=client -o yaml | kubectl apply -f - || { echo 'Failed to create registry pull secret.'; exit 1; }
+
 # Extract DB port and DB host name detail.
 dbPort=$(aws cloudformation describe-stacks --stack-name "${RDS_STACK_NAME}" --region "${EKS_CLUSTER_REGION}" --query 'Stacks[?StackName==`'$RDS_STACK_NAME'`][].Outputs[?OutputKey==`TestgridDBJDBCPort`].OutputValue' --output text | xargs)
 dbHost=$(aws cloudformation describe-stacks --stack-name "${RDS_STACK_NAME}" --region "${EKS_CLUSTER_REGION}" --query 'Stacks[?StackName==`'$RDS_STACK_NAME'`][].Outputs[?OutputKey==`TestgridDBJDBCConnectionString`].OutputValue' --output text | xargs)
@@ -187,6 +199,7 @@ echo "Installing Helm chart - ns ${kubernetes_namespace}  "
 helm install apim "kubernetes-apim/${path_to_helm_folder}" \
     --set-string "wso2.subscription.username=${WUM_USER}" \
     --set-string "wso2.subscription.password=${WUM_PWD}" \
+    --set wso2.deployment.am.imagePullSecrets=wso2-registry-creds \
     --set wso2.subscription.updateLevelState=$updateLevelState \
     --set wso2.deployment.am.cp.db.hostname="$dbHost" \
     --set wso2.deployment.am.cp.db.port="$dbPort" \


### PR DESCRIPTION
## Purpose
`docker.wso2.com` was decommissioned on 2026-08-10. The APIM440 Kubernetes deployment pipeline pulls prebuilt subscription images from it, so every build since has failed — the pods run on Fargate, where an unpullable image leaves them in `Pending` rather than `ImagePullBackOff`, so the build burns the full `kubectl wait --timeout=1800s` and fails after ~165 minutes with no error message.

The `am-pattern-4` chart has been repointed to `registry.wso2.com`, and the image resolves correctly there. What remains is that `wso2.subscription.username` / `password` feed **two** different services:

- the image pull secret → the container registry
- `wso2update_linux` in the container entrypoint → WSO2 Updates

A single account can no longer satisfy both, so the two need separate credentials.

## Goals
Authenticate the image pull with a dedicated registry credential, while leaving the WUM credentials in place for the update tool.

## Approach
In `deploy.sh`, after the Fargate profile is created:

1. Create the namespace up front, so the secret can be placed in it before `helm install` runs.
2. Create a `docker-registry` secret named `wso2-registry-creds` from `REGISTRY_CREDS_USR` / `REGISTRY_CREDS_PSW`, bound in the pipeline `environment` block from the new `wso2-apim_jenkins_image_pull_user` Jenkins credential.
3. Pass `--set wso2.deployment.am.imagePullSecrets=wso2-registry-creds` to `helm install`.

`wso2.deployment.am.imagePullSecrets` already exists in all five AM deployment templates and takes precedence over the subscription-derived secret, so **no Helm chart change is required**. Verified by rendering the chart: all five AM pods reference `wso2-registry-creds`, and `wso2update_linux` still receives the WUM values.

Both `kubectl` calls use `--dry-run=client -o yaml | kubectl apply -f -`, so a rerun against a namespace that survived a previous failure is idempotent. `helm install --create-namespace` is left as-is and is a no-op when the namespace exists.

Scoped to the 4.4.0 line only. The same change applies to `4.3.0-profile-automation` once this is verified green.

## User stories
N/A — CI infrastructure change.

## Release note
N/A — not a product change.

## Documentation
N/A — internal deployment script.

## Training
N/A

## Certification
N/A — no impact on certification exams; this is a CI deployment script change.

## Marketing
N/A

## Automation tests
- Unit tests
  > N/A — shell script.
- Integration tests
  > `bash -n` clean. Chart rendering verified locally with `helm template` at the chart commit the pipeline uses, confirming all five AM pods take the new pull secret and the update tool still receives the WUM credentials. End-to-end verification is the APIM440 pipeline run itself, which is blocked on the Jenkins credential being created.

## Security checks
- Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
- Ran FindSecurityBugs plugin and verified report? N/A — no Java code.
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes — credentials are read from the environment; no values are committed.

Side note: this also improves the handling of the registry credential. It now lives only in a Kubernetes `Secret`, whereas `wso2.subscription.password` is rendered in plaintext into the three entrypoint ConfigMaps (it is on the `wso2update_linux` command line). That pre-existing exposure is unchanged by this PR, but the registry credential no longer shares it.

## Samples
N/A

## Related PRs
- wso2/testgrid-jenkins-library#307 — binds `wso2-apim_jenkins_image_pull_user` in the APIM440 pipeline. Required; this PR is a no-op without it.

## Migrations (if applicable)
Requires the `wso2-apim_jenkins_image_pull_user` credential (Username with password) to exist on the Jenkins controller, scoped to the `Kubernetes-deployments/APIM` folder or global.

## Test environment
`testgrid.wso2.com`, `Kubernetes-deployments/APIM/APIM440`, EKS cluster `testgrid-eks-cluster` (us-east-1), namespace `apim-4-4-0`, chart `advanced/am-pattern-4`.

## Learning
The chart's existing `imagePullSecrets` override made it possible to split the two credentials entirely from the deployment script, with no change to the Helm charts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
