### PR TITLE
[APIM420] Pull images from registry.wso2.com with a dedicated pull secret

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -109,6 +109,18 @@ fi
 # Create fargate profile
 eksctl create fargateprofile --cluster "${EKS_CLUSTER_NAME}" --name "${product_name}-${SHORT_PRODUCT_VERSION}-fargate-profile" --namespace "${kubernetes_namespace}" --region ${EKS_CLUSTER_REGION} || { echo "Failed to create fargate profile." ; exit 1 ; }
 
+# Create the namespace up front so the registry pull secret can be placed in it.
+kubectl create namespace "${kubernetes_namespace}" --dry-run=client -o yaml | kubectl apply -f - || { echo 'Failed to create namespace.'; exit 1; }
+
+# Pull secret for the private container registry. Kept separate from the WSO2 Updates
+# credentials (wso2.subscription.*), which authenticate against a different service.
+kubectl create secret docker-registry wso2-registry-creds \
+    --docker-server=registry.wso2.com \
+    --docker-username="${REGISTRY_CREDS_USR}" \
+    --docker-password="${REGISTRY_CREDS_PSW}" \
+    --namespace "${kubernetes_namespace}" \
+    --dry-run=client -o yaml | kubectl apply -f - || { echo 'Failed to create registry pull secret.'; exit 1; }
+
 # Extract DB port and DB host name detail.
 dbPort=$(aws cloudformation describe-stacks --stack-name "${RDS_STACK_NAME}" --region "${EKS_CLUSTER_REGION}" --query 'Stacks[?StackName==`'$RDS_STACK_NAME'`][].Outputs[?OutputKey==`TestgridDBJDBCPort`].OutputValue' --output text | xargs)
 dbHost=$(aws cloudformation describe-stacks --stack-name "${RDS_STACK_NAME}" --region "${EKS_CLUSTER_REGION}" --query 'Stacks[?StackName==`'$RDS_STACK_NAME'`][].Outputs[?OutputKey==`TestgridDBJDBCConnectionString`].OutputValue' --output text | xargs)
@@ -186,6 +198,9 @@ echo "Installing Helm chart - ns ${kubernetes_namespace}  "
 helm install apim "kubernetes-apim/${path_to_helm_folder}" \
     --set-string "wso2.subscription.username=${WUM_USER}" \
     --set-string "wso2.subscription.password=${WUM_PWD}" \
+    --set wso2.deployment.am.imagePullSecrets=wso2-registry-creds \
+    --set-string "wso2.deployment.am.dockerRegistry=registry.wso2.com" \
+    --set-string "wso2.deployment.am.imageName=wso2-apim/am" \
     --set wso2.subscription.updateLevelState=$updateLevelState \
     --set wso2.deployment.am.cp.db.hostname="$dbHost" \
     --set wso2.deployment.am.cp.db.port="$dbPort" \


### PR DESCRIPTION
## Purpose
`docker.wso2.com` was decommissioned on 2026-08-10, so the APIM420 deployment can no longer pull product images. The pods run on Fargate, where an unpullable image leaves them in `Pending` rather than `ImagePullBackOff`, so the build fails after ~165 minutes with no error message.

Third in the series after #354 (APIM440) and #355 (APIM430), both verified green.

## Goals
Pull APIM420 images from `registry.wso2.com` using a dedicated registry credential, without forking the chart repository.

## Approach
APIM420 differs from the 4.3.0 and 4.4.0 lines. Those use `chamilaadhi/kubernetes-apim`, whose charts were already repointed at `registry.wso2.com`. APIM420 uses upstream `wso2/kubernetes-apim@4.2.x`, which still declares `dockerRegistry: "docker.wso2.com"` and `imageName: "wso2am"` — a single-segment name Harbor rejects.

Upstream `wso2/kubernetes-apim` is marked deprecated, so rather than fork it, this overrides the values on the `helm install`:

```
--set wso2.deployment.am.imagePullSecrets=wso2-registry-creds
--set-string "wso2.deployment.am.dockerRegistry=registry.wso2.com"
--set-string "wso2.deployment.am.imageName=wso2-apim/am"
```

Plus, as in #354/#355, the namespace is created up front and a `docker-registry` secret is built from `REGISTRY_CREDS_USR` / `REGISTRY_CREDS_PSW`, bound in the pipeline `environment` block from the `wso2-apim_jenkins_image_pull_user` Jenkins credential.

`wso2.deployment.am.imagePullSecrets` already exists in all five AM deployment templates on 4.2.x and takes precedence over the subscription-derived secret. Verified by rendering the chart: all five AM pods reference `wso2-registry-creds` and resolve `registry.wso2.com/wso2-apim/am:4.2.0.0`.

`imageTag` needs no override here because 4.2.x already declares a four-part `4.2.0.0`. That is worth knowing before this is repeated for 4.1.x and 4.0.x, which declare three-part tags and rely on the chart appending `.0` — logic that is conditional on the registry being `docker.wso2.com` and would silently stop applying.

`wso2.subscription.*` is left unchanged. It selects the private-registry branch in `_helpers.tpl`, and the entrypoint this repo injects (see Learning) uses it to authenticate `wso2update_linux` at container start.

Both `kubectl` calls use `--dry-run=client -o yaml | kubectl apply -f -`, so a rerun against a namespace that survived a previous failure is idempotent.

## User stories
N/A — CI infrastructure change.

## Release note
N/A — not a product change.

## Documentation
N/A — internal deployment script.

## Training
N/A

## Certification
N/A — no impact on certification exams; this is a CI deployment script change.

## Marketing
N/A

## Automation tests
- Unit tests
  > N/A — shell script.
- Integration tests
  > `bash -n` clean. Chart rendering verified locally at `wso2/kubernetes-apim@4.2.x`. End-to-end verified by running the APIM420 pipeline against this branch — build #301, SUCCESS, 195/195 tests passing. See the comment below.

## Security checks
- Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
- Ran FindSecurityBugs plugin and verified report? N/A — no Java code.
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes — credentials are read from the environment; no values are committed.

## Samples
N/A

## Related PRs
- wso2/testgrid-jenkins-library#309 — binds `wso2-apim_jenkins_image_pull_user` in the APIM420 pipeline. Required; this PR is a no-op without it.
- wso2/apim-test-integration#354 (APIM440), #355 (APIM430) — the equivalent changes.

## Migrations (if applicable)
Requires the `wso2-apim_jenkins_image_pull_user` credential (Username with password) on the Jenkins controller, scoped to the `Kubernetes-deployments/APIM` folder or global. Already created.

## Test environment
`testgrid.wso2.com`, `Kubernetes-deployments/APIM/APIM420`, EKS cluster `testgrid-eks-cluster` (us-east-1), namespace `apim-4-2-0`, chart `advanced/am-pattern-4` @ `wso2/kubernetes-apim@4.2.x`.

## Learning
This repo ships its own chart templates under `resources/`, and `resources/advanced/am-pattern-4/modify-resources.sh` seds them into the checked-out `wso2/kubernetes-apim` chart at deploy time — including an entrypoint ConfigMap that mounts over the image's `/home/wso2carbon/docker-entrypoint.sh` and runs `wso2update_linux`.

So the deployed chart is not the chart as checked out, and `--set wso2.subscription.updateLevelState` is consumed by that injected entrypoint, not by the upstream chart. Worth knowing before reasoning about this deployment from `wso2/kubernetes-apim` alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
