### PR TITLE
[APIM410] Pull images from registry.wso2.com with a dedicated pull secret

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -109,6 +109,18 @@ fi
 # Create fargate profile
 eksctl create fargateprofile --cluster "${EKS_CLUSTER_NAME}" --name "${product_name}-${SHORT_PRODUCT_VERSION}-fargate-profile" --namespace "${kubernetes_namespace}" --region ${EKS_CLUSTER_REGION} || { echo "Failed to create fargate profile." ; exit 1 ; }
 
+# Create the namespace up front so the registry pull secret can be placed in it.
+kubectl create namespace "${kubernetes_namespace}" --dry-run=client -o yaml | kubectl apply -f - || { echo 'Failed to create namespace.'; exit 1; }
+
+# Pull secret for the private container registry. Kept separate from the WSO2 Updates
+# credentials (wso2.subscription.*), which authenticate against a different service.
+kubectl create secret docker-registry wso2-registry-creds \
+    --docker-server=registry.wso2.com \
+    --docker-username="${REGISTRY_CREDS_USR}" \
+    --docker-password="${REGISTRY_CREDS_PSW}" \
+    --namespace "${kubernetes_namespace}" \
+    --dry-run=client -o yaml | kubectl apply -f - || { echo 'Failed to create registry pull secret.'; exit 1; }
+
 # Extract DB port and DB host name detail.
 dbPort=$(aws cloudformation describe-stacks --stack-name "${RDS_STACK_NAME}" --region "${EKS_CLUSTER_REGION}" --query 'Stacks[?StackName==`'$RDS_STACK_NAME'`][].Outputs[?OutputKey==`TestgridDBJDBCPort`].OutputValue' --output text | xargs)
 dbHost=$(aws cloudformation describe-stacks --stack-name "${RDS_STACK_NAME}" --region "${EKS_CLUSTER_REGION}" --query 'Stacks[?StackName==`'$RDS_STACK_NAME'`][].Outputs[?OutputKey==`TestgridDBJDBCConnectionString`].OutputValue' --output text | xargs)
@@ -184,6 +196,9 @@ updateLevelState='TESTING'
 helm install apim "kubernetes-apim/${path_to_helm_folder}" \
     --set-string "wso2.subscription.username=${WUM_USER}" \
     --set-string "wso2.subscription.password=${WUM_PWD}" \
+    --set wso2.deployment.am.imagePullSecrets=wso2-registry-creds \
+    --set-string "wso2.deployment.am.dockerRegistry=registry.wso2.com" \
+    --set-string "wso2.deployment.am.imageName=wso2-apim/am" \
     --set wso2.subscription.updateLevelState=$updateLevelState \
     --set wso2.deployment.am.cp.db.hostname="$dbHost" \
     --set wso2.deployment.am.cp.db.port="$dbPort" \


### PR DESCRIPTION
## Purpose
`docker.wso2.com` was decommissioned on 2026-08-10, so the APIM410 deployment can no longer pull product images.

Fourth in the series after #354 (APIM440), #355 (APIM430) and #356 (APIM420).

## Goals
Pull APIM410 images from `registry.wso2.com` using a dedicated registry credential, without forking the chart repository.

## Approach
APIM410 uses upstream `wso2/kubernetes-apim@4.1.x`, which still declares `docker.wso2.com` and a single-segment `wso2am` image name that Harbor rejects. Upstream is marked deprecated, so rather than fork it, this overrides the values on the `helm install`:

```
--set wso2.deployment.am.imagePullSecrets=wso2-registry-creds
--set-string "wso2.deployment.am.dockerRegistry=registry.wso2.com"
--set-string "wso2.deployment.am.imageName=wso2-apim/am"
```

Plus, as in #354/#355/#356, the namespace is created up front and a `docker-registry` secret is built from `REGISTRY_CREDS_USR` / `REGISTRY_CREDS_PSW`.

**No `imageTag` override is needed.** The 4.1.x chart declares a three-part `4.1.0` and relies on `_helpers.tpl` appending `.0` — logic gated on the registry being `docker.wso2.com`, so it stops applying here. That turns out to be harmless: `registry.wso2.com` publishes both tags at the same digest.

```
registry.wso2.com/wso2-apim/am:4.1.0    -> sha256:2e40bf9a5078f429216d61ec13f65bc89406f4650955fc9184ff6c72545c797f
registry.wso2.com/wso2-apim/am:4.1.0.0  -> sha256:2e40bf9a5078f429216d61ec13f65bc89406f4650955fc9184ff6c72545c797f
```

Verified by running `resources/advanced/am-pattern-4/modify-resources.sh` against a fresh `4.1.x` checkout and rendering the result: all five AM pods take `wso2-registry-creds`, resolve `registry.wso2.com/wso2-apim/am:4.1.0`, and retain the injected update entrypoint with `updateLevelState` wired through.

`wso2.subscription.*` is left unchanged — it selects the private-registry branch in `_helpers.tpl` and authenticates `wso2update_linux` in the entrypoint this repo injects.

## User stories
N/A — CI infrastructure change.

## Release note
N/A — not a product change.

## Documentation
N/A — internal deployment script.

## Training
N/A

## Certification
N/A — no impact on certification exams.

## Marketing
N/A

## Automation tests
- Unit tests
  > N/A — shell script.
- Integration tests
  > `bash -n` clean; chart rendering verified locally as described above. End-to-end run: APIM410 build **#306**. The deployment succeeded — all five pods pulled from `registry.wso2.com` and reached `condition met`, and 181 tests passed. The build is red on 12 failures in one suite that are unrelated to this change; see the comment below.

## Security checks
- Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
- Ran FindSecurityBugs plugin and verified report? N/A — no Java code.
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes — credentials are read from the environment.

## Samples
N/A

## Related PRs
- wso2/testgrid-jenkins-library#310 — binds the credential for APIM410. Required; this PR is a no-op without it.
- wso2/apim-test-integration#354 (APIM440), #355 (APIM430), #356 (APIM420).

## Migrations (if applicable)
Requires the `wso2-apim_jenkins_image_pull_user` credential on the Jenkins controller, scoped to `Kubernetes-deployments/APIM` or global. Already created.

## Test environment
`testgrid.wso2.com`, `Kubernetes-deployments/APIM/APIM410`, EKS cluster `testgrid-eks-cluster` (us-east-1), namespace `apim-4-1-0`, chart `advanced/am-pattern-4` @ `wso2/kubernetes-apim@4.1.x`.

## Learning
`modify-resources.sh` patches the checked-out chart before `helm install`, so the deployed chart is never the chart as checked out. Reasoning about this deployment from `wso2/kubernetes-apim` alone gives the wrong answer — the entrypoint that runs the update tool comes from this repo's `resources/`, not from the chart or the image.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
